### PR TITLE
Bump version number

### DIFF
--- a/docs/conceptual/fsharp-core-library-reference.md
+++ b/docs/conceptual/fsharp-core-library-reference.md
@@ -4,7 +4,7 @@ The F# Core Library (FSharp.Core.dll) contains functions that support the core l
 
 
 ## FSharp.Core Versions
-There are different versions of the F# Core library for each release of the F# language (2.0, 3.0, and 3.1) and for targeting different platforms. The following table summarizes the versions.
+There are different versions of the F# Core library for each release of the F# language (2.0, 3.0, 3.1 and 4.0) and for targeting different platforms. The following table summarizes the versions.
 
 
 

--- a/docs/conceptual/visual-fsharp.md
+++ b/docs/conceptual/visual-fsharp.md
@@ -2,7 +2,7 @@
 
 F# is a programming language that provides support for functional programming in addition to traditional object-oriented and imperative (procedural) programming. The Visual F# product provides support for developing F# applications and extending other .NET Framework applications by using F# code. F# is a first-class member of the .NET Framework languages and retains a strong resemblance to the ML family of functional languages.
 
-This version of Visual F# contains the F# 3.1 version of the language.
+This version of Visual F# contains the F# 4.0 version of the language.
 
 
 ## Multiple-Paradigm Language


### PR DESCRIPTION
It seems that doc content for 4.0 features hasn't been added. But it seems to make sense to bump the version number, either straight away or when it has.