### PR TITLE
Added documentation of Seq.item,

### DIFF
--- a/docs/conceptual/TOC.md
+++ b/docs/conceptual/TOC.md
@@ -431,6 +431,7 @@
 ######[Seq.init<'T> Function (F#)](seq.init['t]-function-[fsharp].md)
 ######[Seq.initInfinite<'T> Function (F#)](seq.initinfinite['t]-function-[fsharp].md)
 ######[Seq.isEmpty<'T> Function (F#)](seq.isempty['t]-function-[fsharp].md)
+######[Seq.item<'T> Function (F#)](seq.item['t]-function-[fsharp].md)
 ######[Seq.iter<'T> Function (F#)](seq.iter['t]-function-[fsharp].md)
 ######[Seq.iteri<'T> Function (F#)](seq.iteri['t]-function-[fsharp].md)
 ######[Seq.iter2<'T1,'T2> Function (F#)](seq.iter2['t1,'t2]-function-[fsharp].md)

--- a/docs/conceptual/seq.item['t]-function-[fsharp].md
+++ b/docs/conceptual/seq.item['t]-function-[fsharp].md
@@ -46,8 +46,6 @@ Type: [seq](http://msdn.microsoft.com/en-us/library/2f0c87c6-8a0d-4d33-92a6-10d1
 The input sequence.
 
 
-
-**exceptions tag is not supported!!!!**
 **The result sequence.**
 ## Remarks
 This function is named **Item** in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.

--- a/docs/conceptual/seq.item['t]-function-[fsharp].md
+++ b/docs/conceptual/seq.item['t]-function-[fsharp].md
@@ -1,0 +1,72 @@
+---
+title: Seq.item<'T> Function (F#)
+description: Seq.item<'T> Function (F#)
+keywords: visual f#, f#, functional programming
+author: ploeh
+manager: danielfe
+ms.date: 05/18/2016
+ms.topic: language-reference
+ms.prod: visual-studio-dev14
+ms.assetid: ea57122a-933d-4522-b71e-e910a7021afa 
+---
+
+# Seq.item<'T> Function (F#)
+
+Computes the *nth* element in the collection.
+
+**Namespace/Module Path:** Microsoft.FSharp.Collections.Seq
+
+**Assembly:** FSharp.Core (in FSharp.Core.dll)
+
+
+## Syntax
+
+
+
+```
+// Signature:
+Seq.item : int -> seq<'T> -> 'T
+
+// Usage:
+Seq.item index source
+```
+
+#### Parameters
+*index*
+Type: [int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)
+
+
+The index of element to retrieve.
+
+
+*source*
+Type: [seq](http://msdn.microsoft.com/en-us/library/2f0c87c6-8a0d-4d33-92a6-10d1d037ce75)**&lt;'T&gt;**
+
+
+The input sequence.
+
+
+
+**exceptions tag is not supported!!!!**
+**The result sequence.**
+## Remarks
+This function is named **Item** in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.
+
+
+## Platforms
+Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
+
+
+## Version Information
+**F# Core Library Versions**
+
+Supported in: 4.0, Portable
+
+
+
+
+## See Also
+[Collections.Seq Module &#40;F&#35;&#41;](Collections.Seq-Module-%5BFSharp%5D.md)
+
+[Microsoft.FSharp.Collections Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Collections-Namespace-%5BFSharp%5D.md)
+


### PR DESCRIPTION
since I couldn't find it. In F# 4, `Seq.nth` is deprecated in favour of `Seq.item`, which is a new function, added in F# 4.

In order to add this documentation file, I copied the documentation file for `Seq.nth` and edited it. During that process, I made a few guesses:

- I changed the 'author' metadata field to my GitHub name 'ploeh' (but left 'manager' in place).
- I updated the 'ms.date' metadata field.
- I generated a new GUID for the 'ms.assetid' field.
- I left the '**exceptions tag is not supported!!!!**' line in place, although it looks strange.
- I removed '2.0' from 'Supported in', but left in 'Portable', because, as far as I can tell, `Seq.item` is available in F# Portable (at least in the configuration I tried).

I'll be happy to make corrections on any of the above, but I wanted to submit a minimal pull request without too much second-guessing, in order to solicit remarks.