### PR TITLE
Seq item details

### DIFF
--- a/docs/conceptual/seq.item['t]-function-[fsharp].md
+++ b/docs/conceptual/seq.item['t]-function-[fsharp].md
@@ -36,7 +36,7 @@ Seq.item index source
 Type: [int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)
 
 
-The index of element to retrieve.
+The zero-based index of the element to retrieve.
 
 
 *source*

--- a/docs/conceptual/seq.item['t]-function-[fsharp].md
+++ b/docs/conceptual/seq.item['t]-function-[fsharp].md
@@ -50,6 +50,10 @@ The input sequence.
 ## Remarks
 This function is named **Item** in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.
 
+**The following code example illustrates the use of Seq.item.**
+[!code-fsharp[Main](snippets/fssequences/snippet203.fs)]
+**Output**
+**bar**
 
 ## Platforms
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2

--- a/docs/conceptual/snippets/fssequences/snippet203.fs
+++ b/docs/conceptual/snippets/fssequences/snippet203.fs
@@ -1,0 +1,2 @@
+let secondItem = seq { yield "foo"; yield "bar"; yield "baz" } |> Seq.item 1
+printfn "%s" secondItem


### PR DESCRIPTION
Following up on the discussion about #41, I used the documentation for `List.map2` and `List.map3` as a template for how to add example code.

These two documents deviate from the recommendation in the #41 discussion that examples should be in a new section, and this pull request follows their template. If desired, I'll be happy to update the pull request, though.