### PR TITLE
Async cleanups

### DIFF
--- a/docs/conceptual/async.awaitiasyncresult-method-[fsharp].md
+++ b/docs/conceptual/async.awaitiasyncresult-method-[fsharp].md
@@ -12,16 +12,15 @@ ms.assetid: 38be2b33-a9a3-4717-a6b1-6540a92f4922
 
 # Async.AwaitIAsyncResult Method (F#)
 
-Creates an asynchronous computation that will wait on the **T:System.IAsyncResult**.
+Creates an asynchronous computation that will wait on the **System.IAsyncResult**.
 
 **Namespace/Module Path:** Microsoft.FSharp.Control
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member AwaitIAsyncResult : IAsyncResult * ?int -> Async<bool>
 
@@ -31,41 +30,66 @@ Async.AwaitIAsyncResult (iar, millisecondsTimeout = millisecondsTimeout)
 ```
 
 #### Parameters
-*iar*
-Type: **T:System.IAsyncResult**
 
+*iar*
+Type: **System.IAsyncResult**
 
 The IAsyncResult to wait on.
-
 
 *millisecondsTimeout*
 Type: [int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)
 
-
 The timeout value in milliseconds. If one is not provided then the default value of -1 corresponding to **F:System.Threading.Timeout.Infinite**.
 
 
+**Returns an asynchronous computation that waits on the given System.IAsyncResult.**
 
-**An asynchronous computation that waits on the given T:System.IAsyncResult.**
 ## Remarks
+
 The computation returns **true** if the handle indicated a result within the given timeout.
 
-**The following code example illustrates how to use Async.AwaitIAsyncResult to set up and execute a computation that is triggered when a previous .NET Framework asynchronous operation that produces an T:System.IAsyncResult finishes. In this case, the call to AwaitIAsyncResult causes the operation to wait for a file write operation to be completed before opening the file for reading.**
-<b>codeReference tag is not supported!!!!</b>
+The following code example illustrates how to use Async.AwaitIAsyncResult to set up and execute a computation that is triggered when a previous .NET Framework asynchronous operation that produces an System.IAsyncResult finishes. In this case, the call to AwaitIAsyncResult causes the operation to wait for a file write operation to be completed before opening the file for reading.
+
+```fsharp
+open System.IO
+
+let streamWriter1 = File.CreateText("test1.txt")
+let count = 10000000
+let buffer = Array.init count (fun index -> byte (index % 256)) 
+
+printfn "Writing to file test1.txt."
+let asyncResult = streamWriter1.BaseStream.BeginWrite(buffer, 0, count, null, null)
+
+// Read a file, but use AwaitIAsyncResult to wait for the write operation
+// to be completed before reading.
+let readFile filename asyncResult count = 
+    async {
+        let! returnValue = Async.AwaitIAsyncResult(asyncResult)
+        printfn "Reading from file test1.txt."
+        // Close the file.
+        streamWriter1.Close()
+        // Now open the same file for reading.
+        let streamReader1 = File.OpenText(filename)
+        let! newBuffer = streamReader1.BaseStream.AsyncRead(count)
+        return newBuffer
+    }
+
+let bufferResult = readFile "test1.txt" asyncResult count
+                   |> Async.RunSynchronously
+```
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.awaitiasyncresult-method-[fsharp].md
+++ b/docs/conceptual/async.awaitiasyncresult-method-[fsharp].md
@@ -39,7 +39,7 @@ The IAsyncResult to wait on.
 *millisecondsTimeout*
 Type: [int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)
 
-The timeout value in milliseconds. If one is not provided then the default value of -1 corresponding to **F:System.Threading.Timeout.Infinite**.
+The timeout value in milliseconds. If one is not provided then the default value of -1 corresponding to **System.Threading.Timeout.Infinite**.
 
 
 **Returns an asynchronous computation that waits on the given System.IAsyncResult.**

--- a/docs/conceptual/async.awaittask['t]-method-[fsharp].md
+++ b/docs/conceptual/async.awaittask['t]-method-[fsharp].md
@@ -18,10 +18,9 @@ Returns an asynchronous computation that waits for the given task to complete an
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member AwaitTask : Task<'T> -> Async<'T>
 
@@ -30,28 +29,30 @@ Async.AwaitTask (task)
 ```
 
 #### Parameters
-*task*
-Type: **T:System.Threading.Tasks.Task&#96;1**
 
+*task*
+
+Type: **System.Threading.Tasks.Task&#96;1**
 
 The task to wait for.
 
+**Returns an asynchronous computation object.**
 
-
-**An asynchronous computation object.**
 ## Remarks
 
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
 
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 4.0, Portable
 
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)

--- a/docs/conceptual/async.awaitwaithandle-method-[fsharp].md
+++ b/docs/conceptual/async.awaitwaithandle-method-[fsharp].md
@@ -12,16 +12,15 @@ ms.assetid: 70f5df5a-57b3-471d-8662-ed81be7a3dfa
 
 # Async.AwaitWaitHandle Method (F#)
 
-Creates an asynchronous computation that will wait for the supplied **T:System.Threading.WaitHandle**.
+Creates an asynchronous computation that will wait for the supplied **System.Threading.WaitHandle**.
 
 **Namespace/Module Path:** Microsoft.FSharp.Control
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member AwaitWaitHandle : WaitHandle * ?int -> Async<bool>
 
@@ -31,44 +30,72 @@ Async.AwaitWaitHandle (waitHandle, millisecondsTimeout = millisecondsTimeout)
 ```
 
 #### Parameters
-*waitHandle*
-Type: **T:System.Threading.WaitHandle**
 
+*waitHandle*
+Type: **System.Threading.WaitHandle**
 
 The wait handle that can be signaled.
-
 
 *millisecondsTimeout*
 Type: [int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)
 
+The timeout value in milliseconds. If no timeout value is provided, the default value is -1, which corresponds to System.Threading.Timeout.Infinite.
 
-The timeout value in milliseconds. If no timeout value is provided, the default value is -1, which corresponds to ystem.Threading.Timeout.Infinite.
+**Returns an asynchronous computation that waits on the given System.Threading.WaitHandle object.**
 
-
-
-**An asynchronous computation that waits on the given T:System.Threading.WaitHandle object.**
 ## Remarks
+
 The computation returns true if the handle indicated a result within the given timeout.
 
-**The following code example illustrates how to use Async.AwaitWaitHandle to set up a computation to run when another asynchronous operation is completed, as indicated by a wait handle.**
-<b>codeReference tag is not supported!!!!</b>
+The following code example illustrates how to use Async.AwaitWaitHandle to set up a computation to run when another asynchronous operation is completed, as indicated by a wait handle.
+
+```fsharp
+open System.IO
+
+let streamWriter1 = File.CreateText("test1.txt")
+let count = 10000000
+let buffer = Array.init count (fun index -> byte (index % 256)) 
+
+printfn "Writing to file test1.txt."
+let asyncResult = streamWriter1.BaseStream.BeginWrite(buffer, 0, count, null, null)
+
+// Read a file, but use the waitHandle to wait for the write operation
+// to be completed before reading.
+let readFile filename waitHandle count = 
+    async {
+        let! returnValue = Async.AwaitWaitHandle(waitHandle)
+        printfn "Reading from file test1.txt."
+        // Close the file.
+        streamWriter1.Close()
+        // Now open the same file for reading.
+        let streamReader1 = File.OpenText(filename)
+        let! newBuffer = streamReader1.BaseStream.AsyncRead(count)
+        return newBuffer
+    }
+
+let bufferResult = readFile "test1.txt" asyncResult.AsyncWaitHandle count
+                   |> Async.RunSynchronously
+```
+
 **Output**
-**Writing to file BigFile.dat.**
-**Reading from file BigFile.dat.**
+
+```
+Writing to file BigFile.dat.
+Reading from file BigFile.dat.
+```
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.canceldefaulttoken-method-[fsharp].md
+++ b/docs/conceptual/async.canceldefaulttoken-method-[fsharp].md
@@ -12,16 +12,15 @@ ms.assetid: 4b462587-601c-4a5d-b2ad-86815b67fd1d
 
 # Async.CancelDefaultToken Method (F#)
 
-Raises the cancellation condition for the most recent set of asynchronous computations started without any specific cancellation token. Replaces the global **T:System.Threading.CancellationTokenSource** object with a new global token source for any asynchronous computations created after this point without any specific cancellation token.
+Raises the cancellation condition for the most recent set of asynchronous computations started without any specific cancellation token. Replaces the global **System.Threading.CancellationTokenSource** object with a new global token source for any asynchronous computations created after this point without any specific cancellation token.
 
 **Namespace/Module Path:** Microsoft.FSharp.Control
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member CancelDefaultToken : unit -> unit
 
@@ -30,22 +29,23 @@ Async.CancelDefaultToken ()
 ```
 
 ## Remarks
-**The following example shows how to create a cancellable asynchronous operation in a Windows Forms application. It also shows how to use Async.CancelDefaultToken to cancel the operation.**
+
+The following example shows how to create a cancellable asynchronous operation in a Windows Forms application. It also shows how to use Async.CancelDefaultToken to cancel the operation.
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet5.fs)]
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.cancellationtoken-property-[fsharp].md
+++ b/docs/conceptual/async.cancellationtoken-property-[fsharp].md
@@ -21,7 +21,7 @@ Creates an asynchronous computation that returns the cancellation token governin
 
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member CancellationToken :  Async<CancellationToken>
 
@@ -29,29 +29,28 @@ static member CancellationToken :  Async<CancellationToken>
 Async.CancellationToken
 ```
 
-**An asynchronous computation capable of retrieving the T:System.Threading.CancellationToken from a computation expression.**
+**Returns an asynchronous computation capable of retrieving the System.Threading.CancellationToken from a computation expression.**
+
 ## Remarks
+
 In an asynchronous computation such as the following, a cancellation token can be used to initiate other asynchronous operations that will cancel cooperatively with this workflow.
 
-```
-f#
+```fsharp
 async { let! token = Async.CancellationToken ...}
 ```
 
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.defaultcancellationtoken-property-[fsharp].md
+++ b/docs/conceptual/async.defaultcancellationtoken-property-[fsharp].md
@@ -18,10 +18,9 @@ Gets the default cancellation token for executing asynchronous computations.
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member DefaultCancellationToken :  CancellationToken
 
@@ -29,23 +28,22 @@ static member DefaultCancellationToken :  CancellationToken
 Async.DefaultCancellationToken
 ```
 
-**The default T:System.Threading.CancellationToken object.**
+**Returns the default System.Threading.CancellationToken object.**
+
 ## Remarks
 
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.frombeginend['arg1,'arg2,'arg3,'t]-method-[fsharp].md
+++ b/docs/conceptual/async.frombeginend['arg1,'arg2,'arg3,'t]-method-[fsharp].md
@@ -18,7 +18,6 @@ Creates an asynchronous computation in terms of a Begin/End pair of actions in t
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
 ```
@@ -31,55 +30,44 @@ Async.FromBeginEnd (arg1, arg2, arg3, beginAction, endAction, cancelAction = can
 ```
 
 #### Parameters
+
 *arg1*
 Type: **'Arg1**
 
-
 The first argument for the operation.
-
 
 *arg2*
 Type: **'Arg2**
 
-
 The second argument for the operation.
-
 
 *arg3*
 Type: **'Arg3**
 
-
 The third argument for the operation.
 
-
 *beginAction*
-Type: **'Arg1 &#42; 'Arg2 &#42; 'Arg3 &#42;****T:System.AsyncCallback****&#42;**[obj](http://msdn.microsoft.com/en-us/library/dcf2430f-702b-40e5-a0a1-97518bf137f7)**-&gt;****T:System.IAsyncResult**
-
+Type: **'Arg1 &#42; 'Arg2 &#42; 'Arg3 &#42; System.AsyncCallback &#42; [obj](http://msdn.microsoft.com/en-us/library/dcf2430f-702b-40e5-a0a1-97518bf137f7) -&gt; System.IAsyncResult**
 
 The function initiating a traditional CLI asynchronous operation.
 
-
 *endAction*
-Type: **T:System.IAsyncResult****-&gt;   'T**
-
+Type: **System.IAsyncResult -&gt; 'T**
 
 The function completing a traditional CLI asynchronous operation.
 
-
 *cancelAction*
-Type: **(**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**)**
-
+Type: **[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7) -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 An optional function to be executed when a cancellation is requested.
 
+**Returns an asynchronous computation wrapping the given Begin/End functions.**
 
-
-**An asynchronous computation wrapping the given Begin/End functions.**
 ## Remarks
+
 This overload should be used if the operation is qualified by three arguments. For example, the following code creates an asynchronous computation for a web service call.
 
-```
-f#
+```fsharp
 Async.FromBeginEnd(arg1,arg2,arg3,ws.BeginGetWeather,ws.EndGetWeather)
 ```
 
@@ -89,18 +77,19 @@ The computation will respond to cancellation while waiting for the completion of
 
 For an example, see [Async.FromBeginEnd&lt;'T&gt; Method (F#)](http://msdn.microsoft.com/en-us/library/eb24fcb5-36fb-4c9b-8343-02148b327b56).
 
-
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
 
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)

--- a/docs/conceptual/async.frombeginend['arg1,'arg2,'t]-method-[fsharp].md
+++ b/docs/conceptual/async.frombeginend['arg1,'arg2,'t]-method-[fsharp].md
@@ -18,10 +18,9 @@ Creates an asynchronous computation in terms of a Begin/End pair of actions in t
 
 **Assembly**: FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member FromBeginEnd : 'Arg1 * 'Arg2 * ('Arg1 * 'Arg2 * AsyncCallback * obj -> IAsyncResult) * (IAsyncResult -> 'T) * ?(unit -> unit) -> Async<'T>
 
@@ -34,45 +33,35 @@ Async.FromBeginEnd (arg1, arg2, beginAction, endAction, cancelAction = cancelAct
 *arg1*
 Type: **'Arg1**
 
-
 The first argument for the operation.
-
 
 *arg2*
 Type: **'Arg2**
 
-
 The second argument for the operation.
 
-
 *beginAction*
-Type: **'Arg1 &#42; 'Arg2 &#42;****T:System.AsyncCallback****&#42;**[obj](http://msdn.microsoft.com/en-us/library/dcf2430f-702b-40e5-a0a1-97518bf137f7)**-&gt;****T:System.IAsyncResult**
-
+Type: **'Arg1 &#42; 'Arg2 &#42; System.AsyncCallback &#42; [obj](http://msdn.microsoft.com/en-us/library/dcf2430f-702b-40e5-a0a1-97518bf137f7) -&gt; System.IAsyncResult**
 
 The function initiating a traditional CLI asynchronous operation.
 
-
 *endAction*
-Type: **T:System.IAsyncResult****-&gt;   'T**
-
+Type: **System.IAsyncResult -&gt; 'T**
 
 The function completing a traditional CLI asynchronous operation.
 
-
 *cancelAction*
-Type: **(**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**)**
-
+Type: **[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7) -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 An optional function to be executed when a cancellation is requested.
 
+**Returns an asynchronous computation wrapping the given Begin/End functions.**
 
-
-**An asynchronous computation wrapping the given Begin/End functions.**
 ## Remarks
+
 This overload should be used if the operation is qualified by two arguments. For example, the following code creates an asynchronous computation for a web service call.
 
-```
-f#
+```fsharp
 Async.FromBeginEnd(arg1,arg2,ws.BeginGetWeather,ws.EndGetWeather)
 ```
 
@@ -82,21 +71,18 @@ The computation will respond to cancellation while waiting for the completion of
 
 For an example, see [Async.FromBeginEnd&lt;'T&gt; Method (F#)](http://msdn.microsoft.com/en-us/library/eb24fcb5-36fb-4c9b-8343-02148b327b56).
 
-
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.frombeginend['arg1,'t]-method-[fsharp].md
+++ b/docs/conceptual/async.frombeginend['arg1,'t]-method-[fsharp].md
@@ -18,10 +18,9 @@ Creates an asynchronous computation in terms of a Begin/End pair of actions in t
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member FromBeginEnd : 'Arg1 * ('Arg1 * AsyncCallback * obj -> IAsyncResult) * (IAsyncResult -> 'T) * ?(unit -> unit) -> Async<'T>
 
@@ -31,41 +30,34 @@ Async.FromBeginEnd (arg, beginAction, endAction, cancelAction = cancelAction)
 ```
 
 #### Parameters
+
 *arg*
 Type: **'Arg1**
 
-
 The argument for the operation.
 
-
 *beginAction*
-Type: **'Arg1 &#42;****T:System.AsyncCallback****&#42;**[obj](http://msdn.microsoft.com/en-us/library/dcf2430f-702b-40e5-a0a1-97518bf137f7)**-&gt;****T:System.IAsyncResult**
-
+Type: **'Arg1 &#42; System.AsyncCallback &#42; [obj](http://msdn.microsoft.com/en-us/library/dcf2430f-702b-40e5-a0a1-97518bf137f7) -&gt; System.IAsyncResult**
 
 The function initiating a traditional CLI asynchronous operation.
 
-
 *endAction*
-Type: **T:System.IAsyncResult****-&gt; 'T**
-
+Type: **System.IAsyncResult -&gt; 'T**
 
 The function completing a traditional CLI asynchronous operation.
 
-
 *cancelAction*
-Type: **(**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**)**
-
+Type: **[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7) -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 An optional function to be executed when a cancellation is requested.
 
-
-
 **An asynchronous computation wrapping the given Begin/End functions.**
+
 ## Remarks
+
 This overload should be used if the operation is qualified by one argument. For example, you can create an asynchronous computation for a web service call with the following code.
 
-```
-f#
+```fsharp
 Async.FromBeginEnd(place,ws.BeginGetWeather,ws.EndGetWeather)
 ```
 
@@ -75,21 +67,18 @@ The computation will respond to cancellation while waiting for the completion of
 
 For an example, see [Async.FromBeginEnd&lt;'T&gt; Method (F#)](http://msdn.microsoft.com/en-us/library/eb24fcb5-36fb-4c9b-8343-02148b327b56).
 
-
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.frombeginend['t]-method-[fsharp].md
+++ b/docs/conceptual/async.frombeginend['t]-method-[fsharp].md
@@ -18,10 +18,9 @@ Creates an asynchronous computation in terms of a Begin/End pair of actions in t
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member FromBeginEnd : (AsyncCallback * obj -> IAsyncResult) * (IAsyncResult -> 'T) * ?(unit -> unit) -> Async<'T>
 
@@ -31,34 +30,29 @@ Async.FromBeginEnd (beginAction, endAction, cancelAction = cancelAction)
 ```
 
 #### Parameters
-*beginAction*
-Type: **T:System.AsyncCallback****&#42;**[obj](http://msdn.microsoft.com/en-us/library/dcf2430f-702b-40e5-a0a1-97518bf137f7)**-&gt;****T:System.IAsyncResult**
 
+*beginAction*
+Type: **System.AsyncCallback &#42; [obj](http://msdn.microsoft.com/en-us/library/dcf2430f-702b-40e5-a0a1-97518bf137f7) -&gt; System.IAsyncResult**
 
 The function initiating a traditional CLI asynchronous operation.
 
-
 *endAction*
-Type: **T:System.IAsyncResult****-&gt; 'T**
-
+Type: **System.IAsyncResult -&gt; 'T**
 
 The function completing a traditional CLI asynchronous operation.
 
-
 *cancelAction*
-Type: **(**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**)**
-
+Type: **[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7) -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 An optional function to be executed when a cancellation is requested.
 
+**Returns an asynchronous computation wrapping the given Begin/End functions.**
 
-
-**An asynchronous computation wrapping the given Begin/End functions.**
 ## Remarks
+
 For example, the following code creates an asynchronous computation that wraps a web service call.
 
-```
-f#
+```fsharp
 Async.FromBeginEnd(ws.BeginGetWeather,ws.EndGetWeather)
 ```
 
@@ -67,36 +61,47 @@ When the computation is run, *beginFunc* is executed, with a callback which repr
 The computation will respond to cancellation while waiting for the completion of the operation. If a cancellation occurs, and *cancelAction* is specified, then it is executed, and the computation continues to wait for the completion of the operation. If *cancelAction* is not specified, cancellation causes the computation to stop immediately, and subsequent invocations of the callback are ignored.
 
 **The following code example shows how to create an F# asynchronous computation from a .NET asynchronous API that uses the Begin/End pattern. The example uses the .NET socket API in System.Net.Sockets. It is an implementation of a simple server application that accepts a connection, receives data from a client, and sends a response.**
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet200.fs)]
+
 **Output**
-**Listening...**
-**Accepting...**
-**Receiving...**
-**Received 256 bytes from client computer.**
-**Sending...**
-**Completed.****The following code example shows the client code that can be used together with the server code in the previous example.**
+
+```
+Listening...
+Accepting...
+Receiving...
+Received 256 bytes from client computer.
+Sending...
+Completed.
+```
+
+**The following code example shows the client code that can be used together with the server code in the previous example.**
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet20.fs)]
+
 **Sample Output**
-**Server address: 10.80.57.8**
-**Connected to remote host.**
-**Sending data...**
-**Receiving data...**
-**Received data from remote host.**
-**255 254 253 252 251 250 249 248 247 246 ...**
+
+```
+Server address: 10.80.57.8
+Connected to remote host.
+Sending data...
+Receiving data...
+Received data from remote host.
+255 254 253 252 251 250 249 248 247 246 ...
+```
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.fromcontinuations['t]-method-[fsharp].md
+++ b/docs/conceptual/async.fromcontinuations['t]-method-[fsharp].md
@@ -21,7 +21,7 @@ Creates an asynchronous computation that captures the current success, exception
 
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member FromContinuations : (('T -> unit) * (exn -> unit) * (OperationCanceledException -> unit) -> unit) -> Async<'T>
 
@@ -30,16 +30,16 @@ Async.FromContinuations (callback)
 ```
 
 #### Parameters
-*callback*
-Type: **('T -&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**) &#42; (**[exn](http://msdn.microsoft.com/en-us/library/e1569b69-3b30-440b-8c6f-966d1c6a06ab)**-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**) &#42; (****T:System.OperationCanceledException****-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**) -&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)
 
+*callback*
+Type: **('T -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)) &#42; ([exn](http://msdn.microsoft.com/en-us/library/e1569b69-3b30-440b-8c6f-966d1c6a06ab) -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)) &#42; (System.OperationCanceledException -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)) -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 The function that accepts the current success, exception, and cancellation continuations.
 
+**Returns an asynchronous computation that provides the callback with the current continuations.**
 
-
-**An asynchronous computation that provides the callback with the current continuations.**
 ## Remarks
+
 The argument for this method is a lambda expression that takes three continuation functions, which are typically called **cont** (the success continuation), **ccont** (the cancel continuation) and **econt** (the error continuation), as the following code shows:
 
 ```
@@ -48,23 +48,22 @@ Async.FromContinuations (fun (cont, ccont, econt) -> ...)
 
 >[!WARNING] {If you use this method, you must call exactly one of the continuation functions or else throw an exception, in which case F# calls **econt** with the exception on your behalf. If you call more than one continuation, call any continuation more than once, or both call a continuation and throw an exception, any subsequent use of the resulting async object may have undefined behavior.
 
-}
 **The following example illustrates how to use Async.FromContinuations to wrap an event-based asynchronous computation as an F# async.**
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet23.fs)]
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.runsynchronously['t]-method-[fsharp].md
+++ b/docs/conceptual/async.runsynchronously['t]-method-[fsharp].md
@@ -18,10 +18,9 @@ Runs the provided asynchronous computation and awaits its result.
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member RunSynchronously : Async<'T> * ?int * ?CancellationToken -> 'T
 
@@ -31,53 +30,56 @@ Async.RunSynchronously (computation, timeout = timeout, cancellationToken = canc
 ```
 
 #### Parameters
-*computation*
-Type: [Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)**&lt;'T&gt;**
 
+*computation*
+Type: **[Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)&lt;'T&gt;**
 
 The computation to run.
 
-
 *timeout*
-Type: [int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)
+Type: **[int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)**
 
-
-The amount of time in milliseconds to wait for the result of the computation before raising a **T:System.TimeoutException**. If no value is provided for timeout then a default of -1 is used to correspond to **F:System.Threading.Timeout.Infinite**.
-
+The amount of time in milliseconds to wait for the result of the computation before raising a **System.TimeoutException**. If no value is provided for timeout then a default of -1 is used to correspond to **System.Threading.Timeout.Infinite**.
 
 *cancellationToken*
-Type: [CancellationToken](http://msdn.microsoft.com/en-us/library/31a3eafe-b61b-46c4-927d-bc9a3ae357c2)
-
+Type: **[CancellationToken](http://msdn.microsoft.com/en-us/library/31a3eafe-b61b-46c4-927d-bc9a3ae357c2)**
 
 The cancellation token to be associated with the computation. If one is not supplied, the default cancellation token is used.
 
+**Returns the result of the computation.**
 
-
-**The result of the computation.**
 ## Remarks
-If an exception occurs in the asynchronous computation then an exception is re-raised by this function. If no cancellation token is provided then the default cancellation token is used. The timeout parameter is given in milliseconds. A value of -1 is equivalent to **F:System.Threading.Timeout.Infinite**.
 
-If you provide a cancelable cancellation token, the timeout is ignored. Instead, you can implement your own timeout by canceling the operation. A cancellation token is cancelable if its **P:System.Threading.CancellationToken.CanBeCanceled** property is set to **true**.
+If an exception occurs in the asynchronous computation then an exception is re-raised by this function. If no cancellation token is provided then the default cancellation token is used. The timeout parameter is given in milliseconds. A value of -1 is equivalent to **System.Threading.Timeout.Infinite**.
+
+If you provide a cancelable cancellation token, the timeout is ignored. Instead, you can implement your own timeout by canceling the operation. A cancellation token is cancelable if its **System.Threading.CancellationToken.CanBeCanceled** property is set to **true**.
 
 **Async.RunSynchronously** should not be used on the main thread in asynchronous programming environments, such as request handlers in a web server.
 
 **The following example shows how to use Async.RunSynchronously to run an asynchronous computation created by using [Async.Parallel](http://msdn.microsoft.com/en-us/library/aa9b0355-2d55-4858-b943-cbe428de9dc4), with no timeout.**
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet1.fs)]
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet2.fs)]
+
 **Sample Output**
-**The operation has timed out.420 write operations completed successfully.**
+
+```
+The operation has timed out.420 write operations completed successfully.
+```
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.sleep-method-[fsharp].md
+++ b/docs/conceptual/async.sleep-method-[fsharp].md
@@ -12,16 +12,15 @@ ms.assetid: 9244f011-bc01-49a0-ad72-c6c51d7ef6e2
 
 # Async.Sleep Method (F#)
 
-Creates an asynchronous computation that will sleep for the given time. This is scheduled using a **T:System.Threading.Timer** object. The operation will not block operating system threads for the duration of the wait.
+Creates an asynchronous computation that will sleep for the given time. This is scheduled using a **System.Threading.Timer** object. The operation will not block operating system threads for the duration of the wait.
 
 **Namespace/Module Path**: Microsoft.FSharp.Control
 
 **Assembly**: FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member Sleep : int -> Async<unit>
 
@@ -30,54 +29,58 @@ Async.Sleep (millisecondsDueTime)
 ```
 
 #### Parameters
-*millisecondsDueTime*
-Type: [int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)
 
+*millisecondsDueTime*
+Type: **[int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)**
 
 The number of milliseconds to sleep.
 
+**Returns an asynchronous computation that will sleep for the given time.**
 
-
-**exceptions tag is not supported!!!!**
-**An asynchronous computation that will sleep for the given time.**
 ## Remarks
+
 **The following code example shows how to use Async.Sleep to simulate computations that run for specific durations.**
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet6.fs)]
+
 **Sample Output**
-**The output is interleaved, because there are multiple threads running at the same time.**
-**Job Job 0 start**
-**1 start**
-**Job 2 starJob 3 start**
-**Job 4 start**
-**Job 5 start**
-**Job 6 start**
-**Job 7 start**
-**Job 8 start**
-**Job 9 start**
-**t**
-**Job 0 end 0:00:00:01.0091009**
-**Job 1 end 0:00:00:02.0102010**
-**Job 2 end 0:00:00:03.0033003**
-**Job 3 end 0:00:00:04.0074007**
-**Job 4 end 0:00:00:05.0065006**
-**Job 5 end 0:00:00:06.0076007**
-**Job 6 end 0:00:00:07.0007000**
-**Job 7 end 0:00:00:07.9957995**
-**Job 8 end 0:00:00:08.9928992**
-**Job 9 end 0:00:00:09.9919991**
+
+```
+The output is interleaved, because there are multiple threads running at the same time.
+Job Job 0 start
+1 start
+Job 2 starJob 3 start
+Job 4 start
+Job 5 start
+Job 6 start
+Job 7 start
+Job 8 start
+Job 9 start
+t
+Job 0 end 0:00:00:01.0091009
+Job 1 end 0:00:00:02.0102010
+Job 2 end 0:00:00:03.0033003
+Job 3 end 0:00:00:04.0074007
+Job 4 end 0:00:00:05.0065006
+Job 5 end 0:00:00:06.0076007
+Job 6 end 0:00:00:07.0007000
+Job 7 end 0:00:00:07.9957995
+Job 8 end 0:00:00:08.9928992
+Job 9 end 0:00:00:09.9919991
+```
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)

--- a/docs/conceptual/async.startastask['t]-method-[fsharp].md
+++ b/docs/conceptual/async.startastask['t]-method-[fsharp].md
@@ -12,16 +12,15 @@ ms.assetid: 401ec537-0d71-4729-9b84-0b6a8f612f3e
 
 # Async.StartAsTask<'T> Method (F#)
 
-Executes a computation in the thread pool. Returns a **T:System.Threading.Tasks.Task** that will be completed in the corresponding state once the computation terminates (produces the result, throws exception or gets canceled) If no cancellation token is provided then the default cancellation token is used.
+Executes a computation in the thread pool. Returns a **System.Threading.Tasks.Task** that will be completed in the corresponding state once the computation terminates (produces the result, throws exception or gets canceled) If no cancellation token is provided then the default cancellation token is used.
 
 **Namespace/Module Path:** Microsoft.FSharp.Control
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member StartAsTask : Async<'T> * ?TaskCreationOptions * ?CancellationToken -> Task<'T>
 
@@ -31,44 +30,42 @@ Async.StartAsTask (computation, taskCreationOptions = taskCreationOptions, cance
 ```
 
 #### Parameters
-*computation*
-Type: [Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)**&lt;'T&gt;**
 
+*computation*
+Type: **[Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)&lt;'T&gt;**
 
 The computation to execute.
 
-
 *taskCreationOptions*
-Type: **T:System.Threading.Tasks.TaskCreationOptions**
-
+Type: **System.Threading.Tasks.TaskCreationOptions**
 
 Optional task creation options.
 
-
 *cancellationToken*
-Type: **T:System.Threading.CancellationToken**
-
+Type: **System.Threading.CancellationToken**
 
 Optional cancellation token.
 
+**Returns a System.Threading.Tasks.Task&lt;'T&gt; object that represents the given computation.**
 
-
-**A T:System.Threading.Tasks.Task&#96;1 object that represents the given computation.**
 ## Remarks
+
 **The following code example demonstrates the use of Async.StartAsTask.**
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet330.fs)]
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 4.0, Portable
 
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.startchild['t]-method-[fsharp].md
+++ b/docs/conceptual/async.startchild['t]-method-[fsharp].md
@@ -18,10 +18,9 @@ Starts a child computation within an asynchronous workflow. This allows multiple
 
 **Assembly**: FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member StartChild : Async<'T> * ?int -> Async<Async<'T>>
 
@@ -31,27 +30,24 @@ Async.StartChild (computation, millisecondsTimeout = millisecondsTimeout)
 ```
 
 #### Parameters
-*computation*
-Type: [Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)**&lt;'T&gt;**
 
+*computation*
+Type: **[Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)&lt;'T&gt;**
 
 The child computation.
 
-
 *millisecondsTimeout*
-Type: [int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)
+Type: **[int](http://msdn.microsoft.com/en-us/library/025d5455-3622-4ea5-9573-3ecbd4ee1375)**
 
+The timeout value in milliseconds. If one is not provided then the default value is -1, which corresponds to **System.Threading.Timeout.Infinite**.
 
-The timeout value in milliseconds. If one is not provided then the default value is -1, which corresponds to **F:System.Threading.Timeout.Infinite**.
+**Returns a new computation that waits for the input computation to finish.**
 
-
-
-**A new computation that waits for the input computation to finish.**
 ## Remarks
+
 This method should normally be used as the immediate right-hand-side of a **let!** binding in an F# asynchronous workflow, that is:
 
-```
-f#
+```fsharp
 async { 
 ...
 let! completor1 = childComputation1
@@ -67,30 +63,33 @@ let! result2 = completor2
 When used in this way, each use of **StartChild** starts an instance of **childComputation** and returns a **completor** object representing a computation to wait for the completion of the operation. When executed, the **completor** awaits the completion of **childComputation**.
 
 **The following code example illustrates the use of Async.StartChild.**
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet4.fs)]
+
 **Sample Output**
-**The output is interleaved because the jobs are running simultaneously.**
-**ComplParent job start.**
-**eted execution.**
-**Child job start: Child job slongoutput1.dat**
-**tart: longoutput2.dat**
-**Child job end: longoutput2.dat**
-**Child job end: longoutput1.dat**
-**Parent job end.**
+
+```
+The output is interleaved because the jobs are running simultaneously.
+ComplParent job start.
+eted execution.
+Child job start: Child job slongoutput1.dat
+tart: longoutput2.dat
+Child job end: longoutput2.dat
+Child job end: longoutput1.dat
+Parent job end.
+```
+
 ## Platforms
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.startchildastask['t]-method-[fsharp].md
+++ b/docs/conceptual/async.startchildastask['t]-method-[fsharp].md
@@ -12,16 +12,15 @@ ms.assetid: fcc51d5b-30fc-4486-a266-735099154310
 
 # Async.StartChildAsTask<'T> Method (F#)
 
-Creates an asynchronous computation which starts the given computation as a **T:System.Threading.Tasks.Task**.
+Creates an asynchronous computation which starts the given computation as a **System.Threading.Tasks.Task**.
 
 **Namespace/Module Path:** Microsoft.FSharp.Control
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member StartChildAsTask : Async<'T> * ?TaskCreationOptions -> Async<Task<'T>>
 
@@ -31,35 +30,31 @@ Async.StartChildAsTask (computation, taskCreationOptions = taskCreationOptions)
 ```
 
 #### Parameters
-*computation*
-Type: [Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)**&lt;'T&gt;**
 
+*computation*
+Type: **[Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)&lt;'T&gt;**
 
 The computation to execute.
 
-
 *taskCreationOptions*
-Type: **T:System.Threading.Tasks.TaskCreationOptions**
-
+Type: **System.Threading.Tasks.TaskCreationOptions**
 
 Optional task creation options.
 
-
-
-**The task wrapped as an asynchronous computation.**
-## Remarks
+**Returns the task wrapped as an asynchronous computation.**
 
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 4.0, Portable
 
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)

--- a/docs/conceptual/async.startwithcontinuations['t]-method-[fsharp].md
+++ b/docs/conceptual/async.startwithcontinuations['t]-method-[fsharp].md
@@ -18,10 +18,9 @@ Runs an asynchronous computation, starting immediately on the current operating 
 
 **Assembly:** FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member StartWithContinuations : Async<'T> * ('T -> unit) * (exn -> unit) * (OperationCanceledException -> unit) * ?CancellationToken -> unit
 
@@ -31,62 +30,52 @@ Async.StartWithContinuations (computation, continuation, exceptionContinuation, 
 ```
 
 #### Parameters
-*computation*
-Type: [Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)**&lt;'T&gt;**
 
+*computation*
+Type: **[Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)&lt;'T&gt;**
 
 The asynchronous computation to execute.
 
-
 *continuation*
-Type: **'T -&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)
-
+Type: **'T -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 The function called on success.
 
-
 *exceptionContinuation*
-Type: [exn](http://msdn.microsoft.com/en-us/library/e1569b69-3b30-440b-8c6f-966d1c6a06ab)**-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)
-
+Type: **[exn](http://msdn.microsoft.com/en-us/library/e1569b69-3b30-440b-8c6f-966d1c6a06ab) -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 The function called on exception.
 
-
 *cancellationContinuation*
-Type: **T:System.OperationCanceledException****-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)
-
+Type: **System.OperationCanceledException -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 The function called on cancellation.
 
-
 *cancellationToken*
-Type: [CancellationToken](http://msdn.microsoft.com/en-us/library/31a3eafe-b61b-46c4-927d-bc9a3ae357c2)
-
+Type: **[CancellationToken](http://msdn.microsoft.com/en-us/library/31a3eafe-b61b-46c4-927d-bc9a3ae357c2)**
 
 The optional cancellation token to associate with the computation. The default is used if this parameter is not provided.
 
-
-
-
 ## Remarks
+
 If no cancellation token is provided, the default cancellation token is used.
 
 **The following code example illustrates the use of Async.StartWithContinuations.**
+
 [!code-fsharp[Main](snippets/fsasyncapis/snippet5.fs)]
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.switchtocontext-method-[fsharp].md
+++ b/docs/conceptual/async.switchtocontext-method-[fsharp].md
@@ -18,10 +18,9 @@ Creates an asynchronous computation that runs its continuation using the **M:Sys
 
 **Assembly**: FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member SwitchToContext : SynchronizationContext -> Async<unit>
 
@@ -30,34 +29,79 @@ Async.SwitchToContext (syncContext)
 ```
 
 #### Parameters
-*syncContext*
-Type: **T:System.Threading.SynchronizationContext**
 
+*syncContext*
+Type: **System.Threading.SynchronizationContext**
 
 The synchronization context to accept the posted computation.
 
+**Returns an asynchronous computation that uses the syncContext context to execute.**
 
-
-**An asynchronous computation that uses the syncContext context to execute.**
 ## Remarks
+
 If *syncContext* is null then the asynchronous computation is equivalent to [Async.SwitchToThreadPool](http://msdn.microsoft.com/en-us/library/c2708739-5389-487a-a3c9-490f417bcdc6).
 
 **The following code example illustrates how to use Async.SwitchToContext to switch to the UI thread to update the UI. In this, case a progress bar that indicates the state of completion of a computation is updated.**
-<b>codeReference tag is not supported!!!!</b>
+
+```fsharp
+open System.Windows.Forms
+
+let form = new Form(Text = "Test Form", Width = 400, Height = 400)
+let syncContext = System.Threading.SynchronizationContext()
+let button1 = new Button(Text = "Start")
+let label1 = new Label(Text = "", Height = 200, Width = 200,
+                       Top = button1.Height + 10)
+form.Controls.AddRange([| button1; label1 |] )
+
+let async1(syncContext, form : System.Windows.Forms.Form) =
+    async {
+        let label1 = form.Controls.[1]
+        // Do something. 
+        do! Async.Sleep(10000)
+        let threadName = System.Threading.Thread.CurrentThread.Name
+        let threadNumber = System.Threading.Thread.CurrentThread.ManagedThreadId
+        label1.Text <- label1.Text + sprintf "Something [%s] [%d]" threadName threadNumber
+
+        // Switch to the UI thread and update the UI. 
+        do! Async.SwitchToContext(syncContext)
+        let threadName = System.Threading.Thread.CurrentThread.Name
+        let threadNumber = System.Threading.Thread.CurrentThread.ManagedThreadId
+        label1.Text <- label1.Text + sprintf "Here [%s] [%d]" threadName threadNumber
+
+        // Switch back to the thread pool. 
+        do! Async.SwitchToThreadPool()
+        // Do something. 
+        do! Async.Sleep(10000)
+        let threadName = System.Threading.Thread.CurrentThread.Name
+        let threadNumber = System.Threading.Thread.CurrentThread.ManagedThreadId
+        label1.Text <- label1.Text +
+                       sprintf "Switched to thread pool [%s] [%d]" threadName threadNumber
+    }
+
+let buttonClick(sender:obj, args) =
+    let button = sender :?> Button
+    Async.Start(async1(syncContext, button.Parent :?> Form))
+    let threadName = System.Threading.Thread.CurrentThread.Name
+    let threadNumber = System.Threading.Thread.CurrentThread.ManagedThreadId
+    button.Parent.Text <- sprintf "Started asynchronous workflow [%s] [%d]" threadName threadNumber
+    ()
+
+button1.Click.AddHandler(fun sender args -> buttonClick(sender, args))
+Application.Run(form)
+```
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/async.trycancelled['t]-method-[fsharp].md
+++ b/docs/conceptual/async.trycancelled['t]-method-[fsharp].md
@@ -18,10 +18,9 @@ Creates an asynchronous computation that executes the specified computation func
 
 **Assembly**: FSharp.Core (in FSharp.Core.dll)
 
-
 ## Syntax
 
-```
+```fsharp
 // Signature:
 static member TryCancelled : Async<'T> * (OperationCanceledException -> unit) -> Async<'T>
 
@@ -30,39 +29,138 @@ Async.TryCancelled (computation, compensation)
 ```
 
 #### Parameters
+
 *computation*
 Type: [Async](http://msdn.microsoft.com/en-us/library/e0b28ea2-dea5-4021-b2b9-d7d4761babde)**&lt;'T&gt;**
 
-
 The input asynchronous computation.
 
-
 *compensation*
-Type: **T:System.OperationCanceledException****-&gt;**[unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)
-
+Type: **System.OperationCanceledException -&gt; [unit](http://msdn.microsoft.com/en-us/library/00b837c2-6c8a-483a-87d3-0479c64037a7)**
 
 The function to be run if the computation is cancelled.
 
+**Returns an asynchronous computation that runs the compensation function if the input computation is cancelled.**
 
-
-**An asynchronous computation that runs the compensation function if the input computation is cancelled.**
 ## Remarks
+
 **The following code example illustrates how to use Async.TryCancelled to run a cancellable computation.**
-<b>codeReference tag is not supported!!!!</b>
+
+```fsharp
+open System
+open System.Windows.Forms
+
+let form = new Form(Text = "Test Form", Width = 400, Height = 400)
+let panel1 = new Panel(Dock = DockStyle.Fill)
+panel1.DockPadding.All <- 10
+let spacing = 5
+let startAsyncButton = new Button(Text = "Start", Enabled = true)
+let controlHeight = startAsyncButton.Height
+let button2 = new Button(Text = "Start Invalid", Top = controlHeight + spacing)
+let cancelAsyncButton = new Button(Text = "Cancel",
+                                   Top = 2 * (controlHeight + spacing),
+                                   Enabled = false)
+let updown1 = new System.Windows.Forms.NumericUpDown(Top = 3 * (controlHeight + spacing), 
+                                                     Value = 20m, Minimum = 0m,
+                                                     Maximum = 1000000m)
+let label1 = new Label (Text = "", Top = 4 * (controlHeight + spacing),
+                        Width = 300, Height = 2 * controlHeight)
+let progressBar = new ProgressBar(Top = 6 * (controlHeight + spacing),
+                                  Width = 300)
+panel1.Controls.AddRange [| startAsyncButton; button2; cancelAsyncButton;
+                            updown1; label1; progressBar; |]
+form.Controls.Add(panel1)
+
+// Recursive isprime function. 
+let isprime number =
+    let rec check count =
+        count > number/2 || (number % count <> 0 && check (count + 1))
+    check 2
+
+let isprimeBigInt number =
+    let rec check count =
+        count > number/2I || (number % count <> 0I && check (count + 1I))
+    check 2I
+
+let computeNthPrime (number) =
+     if (number < 1) then
+         invalidOp <| sprintf "Invalid input for nth prime: %s." (number.ToString())
+     let mutable count = 0
+     let mutable num = 1I
+     let isDone = false 
+     while (count < number) do
+         num <- num + 1I
+         if (num < bigint System.Int32.MaxValue) then 
+             while (not (isprime (int num))) do
+                 num <- num + 1I
+         else 
+             while (not (isprimeBigInt num)) do
+                 num <- num + 1I
+         count <- count + 1
+     num
+
+let async1 context value =
+    let asyncTryWith =
+        async {
+                    try 
+                        let nthPrime = ref 0I
+                        for count in 1 .. value - 1 do 
+                            // The cancellation check is implicit and 
+                            // cooperative at for!, do!, and so on.
+                            nthPrime := computeNthPrime(count)
+                            // Report progress as a percentage of the total task. 
+                            let percentComplete = (int)((float)count /
+                                                        (float)value * 100.0)
+                            do! Async.SwitchToContext(context)
+                            progressBar.Value <- percentComplete
+                            do! Async.SwitchToThreadPool()
+                        // Handle the case in which the operation succeeds. 
+                        do! Async.SwitchToContext(context)
+                        label1.Text <- sprintf "%s" ((!nthPrime).ToString())
+                    with 
+                        | e -> 
+                            // Handle the case in which an exception is thrown. 
+                            do! Async.SwitchToContext(context)
+                            MessageBox.Show(e.Message) |> ignore
+                }
+    async {
+        try 
+            do! Async.TryCancelled(asyncTryWith,
+                                   (fun oce -> 
+                                      // Handle the case in which the user cancels the operation.
+                                      context.Post((fun _ ->
+                                          label1.Text <- "Canceled"), null)))
+        finally 
+            context.Post((fun _ ->
+                updown1.Enabled <- true
+                startAsyncButton.Enabled <- true
+                cancelAsyncButton.Enabled <- false),
+                null)
+    }
+
+startAsyncButton.Click.Add(fun args -> 
+    cancelAsyncButton.Enabled <- true 
+    let context = System.Threading.SynchronizationContext.Current
+    Async.Start(async1 context (int updown1.Value)))
+button2.Click.Add(fun args ->
+   let context = System.Threading.SynchronizationContext.Current
+   Async.Start(async1 context (int (-updown1.Value))))
+cancelAsyncButton.Click.Add(fun args -> Async.CancelDefaultToken())
+Application.Run(form)
+```
+
 ## Platforms
+
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
-
 ## Version Information
+
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
 
-
-
-
 ## See Also
+
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Control Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Control-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/asynchronous-workflows-[fsharp].md
+++ b/docs/conceptual/asynchronous-workflows-[fsharp].md
@@ -14,26 +14,25 @@ ms.assetid: ee2bb9bf-e04a-4fbe-bf58-46d07229e981
 
 This topic describes support in F# for performing computations asynchronously, that is, without blocking execution of other work. For example, asynchronous computations can be used to write applications that have UIs that remain responsive to users as the application performs other work.
 
-
 ## Syntax
 
-```
+```fsharp
 async { expression }
 ```
 
 ## Remarks
-In the previous syntax, the computation represented by *expression* is set up to run asynchronously, that is, without blocking the current computation thread when asynchronous sleep operations, I/O, and other asynchronous operations are performed. Asynchronous computations are often started on a background thread while execution continues on the current thread. The type of the expression is **Async&lt;'a&gt;**, where **'a** is the type returned by the expression when the **return** keyword is used. The code in such an expression is referred to as an *asynchronous block*, or *async block*.
 
-There are a variety of ways of programming asynchronously, and the [Async](http://msdn.microsoft.com/en-us/library/03eb4d12-a01a-4565-a077-5e83f17cf6f7) class provides methods that support several scenarios. The general approach is to create **Async** objects that represent the computation or computations that you want to run asynchronously, and then start these computations by using one of the triggering functions. The various triggering functions provide different ways of running asynchronous computations, and which one you use depends on whether you want to use the current thread, a background thread, or a .NET Framework task object, and whether there are continuation functions that should run when the computation finishes. For example, to start an asynchronous computation on the current thread, you can use [Async.StartImmediate](http://msdn.microsoft.com/en-us/library/2f71d1cc-187f-48cf-ac66-e7fda41c46e3). When you start an asynchronous computation from the UI thread, you do not block the main event loop that processes user actions such as keystrokes and mouse activity, so your application remains responsive.
+In the previous syntax, the computation represented by *expression* is set up to run asynchronously, that is, without blocking the current computation thread when asynchronous sleep operations, I/O, and other asynchronous operations are performed. Asynchronous computations are often started on a background thread while execution continues on the current thread. The type of the expression is **Async&lt;'T&gt;**, where **'T** is the type returned by the expression when the **return** keyword is used. The code in such an expression is referred to as an *asynchronous block*, or *async block*.
 
+There are a variety of ways of programming asynchronously, and the **[Async](http://msdn.microsoft.com/en-us/library/03eb4d12-a01a-4565-a077-5e83f17cf6f7)** class provides methods that support several scenarios. The general approach is to create **Async** objects that represent the computation or computations that you want to run asynchronously, and then start these computations by using one of the triggering functions. The various triggering functions provide different ways of running asynchronous computations, and which one you use depends on whether you want to use the current thread, a background thread, or a .NET Framework task object, and whether there are continuation functions that should run when the computation finishes. For example, to start an asynchronous computation on the current thread, you can use [Async.StartImmediate](http://msdn.microsoft.com/en-us/library/2f71d1cc-187f-48cf-ac66-e7fda41c46e3). When you start an asynchronous computation from the UI thread, you do not block the main event loop that processes user actions such as keystrokes and mouse activity, so your application remains responsive.
 
 ## Asynchronous Binding by Using let!
+
 In an asynchronous workflow, some expressions and operations are synchronous, and some are longer computations that are designed to return a result asynchronously. When you call a method asynchronously, instead of an ordinary **let** binding, you use **let!**. The effect of **let!** is to enable execution to continue on other computations or threads as the computation is being performed. After the right side of the **let!** binding returns, the rest of the asynchronous workflow resumes execution.
 
 The following code shows the difference between **let** and **let!**. The line of code that uses **let** just creates an asynchronous computation as an object that you can run later by using, for example, **Async.StartImmediate** or [Async.RunSynchronously](http://msdn.microsoft.com/en-us/library/0a6663a9-50f2-4d38-8bf3-cefd1a51fd6b). The line of code that uses **let!** starts the computation, and then the thread is suspended until the result is available, at which point execution continues.
 
-```
-f#
+```fsharp
 // let just stores the result as an asynchronous operation.
 let (result1 : Async<byte[]>) = stream.AsyncRead(bufferSize)
 // let! completes the asynchronous operation and returns the data.
@@ -42,11 +41,11 @@ let! (result2 : byte[])  = stream.AsyncRead(bufferSize)
 
 In addition to **let!**, you can use **use!** to perform asynchronous bindings. The difference between **let!** and **use!** is the same as the difference between **let** and **use**. For **use!**, the object is disposed of at the close of the current scope. Note that in the current release of the F# language, **use!** does not allow a value to be initialized to null, even though **use** does.
 
-
 ## Asynchronous Primitives
-A method that performs a single asynchronous task and returns the result is called an *asynchronous primitive*, and these are designed specifically for use with **let!**. Several asynchronous primitives are defined in the F# core library. Two such methods for Web applications are defined in the module [Microsoft.FSharp.Control.WebExtensions](http://msdn.microsoft.com/en-us/library/95ef17bc-ee3f-44ba-8a11-c90fcf4cf003): [WebRequest.AsyncGetResponse](http://msdn.microsoft.com/en-us/library/09a60c31-e6e2-4b5c-ad23-92a86e50060c) and [WebClient.AsyncDownloadString](http://msdn.microsoft.com/en-us/library/8a85a9b7-f712-4cac-a0ce-0a797f8ea32a). Both primitives download data from a Web page, given a URL. **AsyncGetResponse** produces a **T:System.Net.WebResponse** object, and **AsyncDownloadString** produces a string that represents the HTML for a Web page.
 
-Several primitives for asynchronous I/O operations are included in the [Microsoft.FSharp.Control.CommonExtensions](http://msdn.microsoft.com/en-us/library/2edb67cb-6814-4a30-849f-b6dbdd042396) module. These extension methods of the **T:System.IO.Stream** class are [Stream.AsyncRead](http://msdn.microsoft.com/en-us/library/85698aaa-bdda-47e6-abed-3730f59fda5e) and [Stream.AsyncWrite](http://msdn.microsoft.com/en-us/library/1b0a2751-e42a-47e1-bd27-020224adc618).
+A method that performs a single asynchronous task and returns the result is called an *asynchronous primitive*, and these are designed specifically for use with **let!**. Several asynchronous primitives are defined in the F# core library. Two such methods for Web applications are defined in the module [Microsoft.FSharp.Control.WebExtensions](http://msdn.microsoft.com/en-us/library/95ef17bc-ee3f-44ba-8a11-c90fcf4cf003): [WebRequest.AsyncGetResponse](http://msdn.microsoft.com/en-us/library/09a60c31-e6e2-4b5c-ad23-92a86e50060c) and [WebClient.AsyncDownloadString](http://msdn.microsoft.com/en-us/library/8a85a9b7-f712-4cac-a0ce-0a797f8ea32a). Both primitives download data from a Web page, given a URL. **AsyncGetResponse** produces a **System.Net.WebResponse** object, and **AsyncDownloadString** produces a string that represents the HTML for a Web page.
+
+Several primitives for asynchronous I/O operations are included in the [Microsoft.FSharp.Control.CommonExtensions](http://msdn.microsoft.com/en-us/library/2edb67cb-6814-4a30-849f-b6dbdd042396) module. These extension methods of the **System.IO.Stream** class are [Stream.AsyncRead](http://msdn.microsoft.com/en-us/library/85698aaa-bdda-47e6-abed-3730f59fda5e) and [Stream.AsyncWrite](http://msdn.microsoft.com/en-us/library/1b0a2751-e42a-47e1-bd27-020224adc618).
 
 Additional asynchronous primitives are available in the F# PowerPack. You can also write your own asynchronous primitives by defining a function whose complete body is enclosed in an async block.
 
@@ -55,14 +54,19 @@ To use asynchronous methods in the .NET Framework that are designed for other as
 One example of using asynchronous workflows is included here; there are many others in the documentation for the methods of the [Async class](http://msdn.microsoft.com/en-us/library/03eb4d12-a01a-4565-a077-5e83f17cf6f7).
 
 **This example shows how to use asynchronous workflows to perform computations in parallel.**
+
 **In the following code example, a function fetchAsync gets the HTML text returned from a Web request. The fetchAsync function contains an asynchronous block of code. When a binding is made to the result of an asynchronous primitive, in this case [AsyncDownloadString](http://msdn.microsoft.com/en-us/library/8a85a9b7-f712-4cac-a0ce-0a797f8ea32a), let! is used instead of let.**
+
 **You use the function [Async.RunSynchronously](http://msdn.microsoft.com/en-us/library/0a6663a9-50f2-4d38-8bf3-cefd1a51fd6b) to execute an asynchronous operation and wait for its result. As an example, you can execute multiple asynchronous operations in parallel by using the [Async.Parallel](http://msdn.microsoft.com/en-us/library/aa9b0355-2d55-4858-b943-cbe428de9dc4) function together with the Async.RunSynchronously function. The Async.Parallel function takes a list of the Async objects, sets up the code for each Async task object to run in parallel, and returns an Async object that represents the parallel computation. Just as for a single operation, you call Async.RunSynchronously to start the execution.**
+
 **The runAll function launches three asynchronous workflows in parallel and waits until they have all completed.**
+
 [!code-fsharp[Main](snippets/fslangref2/snippet8003.fs)]
+
 ## See Also
+
 [F&#35; Language Reference](FSharp-Language-Reference.md)
 
 [Computation Expressions &#40;F&#35;&#41;](Computation-Expressions-%5BFSharp%5D.md)
 
 [Control.Async Class &#40;F&#35;&#41;](Control.Async-Class-%5BFSharp%5D.md)
-


### PR DESCRIPTION
This is work for issue #61 - Cleanups of the Async docs.

Note that many code samples didn't port - I pulled them (verbatim) from cached versions of the old MSDN docs.