### PR TITLE
fix indentation and prefix empty lines for list code snippets

### DIFF
--- a/docs/conceptual/snippets/fslists/snippet1.fs
+++ b/docs/conceptual/snippets/fslists/snippet1.fs
@@ -1,4 +1,3 @@
-
 // Use List.exists to determine whether there is an element of a list satisfies a given Boolean expression.
 // containsNumber returns true if any of the elements of the supplied list match 
 // the supplied number.

--- a/docs/conceptual/snippets/fslists/snippet10.fs
+++ b/docs/conceptual/snippets/fslists/snippet10.fs
@@ -1,4 +1,3 @@
-
 let list1d = [1; 3; 7; 9; 11; 13; 15; 19; 22; 29; 36]
 let isEven x = x % 2 = 0
 match List.tryFind isEven list1d with

--- a/docs/conceptual/snippets/fslists/snippet11.fs
+++ b/docs/conceptual/snippets/fslists/snippet11.fs
@@ -1,12 +1,10 @@
+// Compute the sum of the first 10 integers by using List.sum.
+let sum1 = List.sum [1 .. 10]
 
-    // Compute the sum of the first 10 integers by using List.sum.
-    let sum1 = List.sum [1 .. 10]
+// Compute the sum of the squares of the elements of a list by using List.sumBy.
+let sum2 = List.sumBy (fun elem -> elem*elem) [1 .. 10]
 
-    // Compute the sum of the squares of the elements of a list by using List.sumBy.
-    let sum2 = List.sumBy (fun elem -> elem*elem) [1 .. 10]
+// Compute the average of the elements of a list by using List.average.
+let avg1 = List.average [0.0; 1.0; 1.0; 2.0]
 
-
-    // Compute the average of the elements of a list by using List.average.
-    let avg1 = List.average [0.0; 1.0; 1.0; 2.0]
-
-    printfn "%f" avg1
+printfn "%f" avg1

--- a/docs/conceptual/snippets/fslists/snippet111.fs
+++ b/docs/conceptual/snippets/fslists/snippet111.fs
@@ -1,5 +1,4 @@
+// Compute the average of the elements of a list by using List.average.
+let avg1 = List.average [0.0; 1.0; 1.0; 2.0]
 
-    // Compute the average of the elements of a list by using List.average.
-    let avg1 = List.average [0.0; 1.0; 1.0; 2.0]
-
-    printfn "%f" avg1
+printfn "%f" avg1

--- a/docs/conceptual/snippets/fslists/snippet12.fs
+++ b/docs/conceptual/snippets/fslists/snippet12.fs
@@ -1,3 +1,2 @@
-
 let avg2 = List.averageBy (fun elem -> float elem) [1 .. 10]
 printfn "%f" avg2

--- a/docs/conceptual/snippets/fslists/snippet13.fs
+++ b/docs/conceptual/snippets/fslists/snippet13.fs
@@ -1,5 +1,4 @@
-
-    let list1 = [ 1; 2; 3 ]
-    let list2 = [ -1; -2; -3 ]
-    let listZip = List.zip list1 list2
-    printfn "%A" listZip
+let list1 = [ 1; 2; 3 ]
+let list2 = [ -1; -2; -3 ]
+let listZip = List.zip list1 list2
+printfn "%A" listZip

--- a/docs/conceptual/snippets/fslists/snippet14.fs
+++ b/docs/conceptual/snippets/fslists/snippet14.fs
@@ -1,4 +1,3 @@
-
-    let list3 = [ 0; 0; 0]
-    let listZip3 = List.zip3 list1 list2 list3
-    printfn "%A" listZip3
+let list3 = [ 0; 0; 0]
+let listZip3 = List.zip3 list1 list2 list3
+printfn "%A" listZip3

--- a/docs/conceptual/snippets/fslists/snippet15.fs
+++ b/docs/conceptual/snippets/fslists/snippet15.fs
@@ -1,4 +1,3 @@
-
 let lists = List.unzip [(1,2); (3,4)]
 printfn "%A" lists
 printfn "%A %A" (fst lists) (snd lists)

--- a/docs/conceptual/snippets/fslists/snippet16.fs
+++ b/docs/conceptual/snippets/fslists/snippet16.fs
@@ -1,3 +1,2 @@
-
 let listsUnzip3 = List.unzip3 [(1,2,3); (4,5,6)]
 printfn "%A" listsUnzip3

--- a/docs/conceptual/snippets/fslists/snippet17.fs
+++ b/docs/conceptual/snippets/fslists/snippet17.fs
@@ -1,10 +1,9 @@
-
-    let list1 = [1; 2; 3]
-    let list2 = [4; 5; 6]
-    List.iter (fun x -> printfn "List.iter: element is %d" x) list1
-    List.iteri(fun i x -> printfn "List.iteri: element %d is %d" i x) list1
-    List.iter2 (fun x y -> printfn "List.iter2: elements are %d %d" x y) list1 list2
-    List.iteri2 (fun i x y ->
-                   printfn "List.iteri2: element %d of list1 is %d element %d of list2 is %d"
-                     i x i y)
-                list1 list2
+let list1 = [1; 2; 3]
+let list2 = [4; 5; 6]
+List.iter (fun x -> printfn "List.iter: element is %d" x) list1
+List.iteri(fun i x -> printfn "List.iteri: element %d is %d" i x) list1
+List.iter2 (fun x y -> printfn "List.iter2: elements are %d %d" x y) list1 list2
+List.iteri2 (fun i x y ->
+                printfn "List.iteri2: element %d of list1 is %d element %d of list2 is %d"
+                  i x i y)
+            list1 list2

--- a/docs/conceptual/snippets/fslists/snippet18.fs
+++ b/docs/conceptual/snippets/fslists/snippet18.fs
@@ -1,4 +1,3 @@
-
-    let list1 = [1; 2; 3]
-    let newList = List.map (fun x -> x + 1) list1
-    printfn "%A" newList
+let list1 = [1; 2; 3]
+let newList = List.map (fun x -> x + 1) list1
+printfn "%A" newList

--- a/docs/conceptual/snippets/fslists/snippet19.fs
+++ b/docs/conceptual/snippets/fslists/snippet19.fs
@@ -1,5 +1,4 @@
-
-    let list1 = [1; 2; 3]
-    let list2 = [4; 5; 6]
-    let sumList = List.map2 (fun x y -> x + y) list1 list2
-    printfn "%A" sumList
+let list1 = [1; 2; 3]
+let list2 = [4; 5; 6]
+let sumList = List.map2 (fun x y -> x + y) list1 list2
+printfn "%A" sumList

--- a/docs/conceptual/snippets/fslists/snippet2.fs
+++ b/docs/conceptual/snippets/fslists/snippet2.fs
@@ -1,4 +1,3 @@
-
 // Use List.exists2 to compare elements in two lists.
 // isEqualElement returns true if any elements at the same position in two supplied
 // lists match.

--- a/docs/conceptual/snippets/fslists/snippet20.fs
+++ b/docs/conceptual/snippets/fslists/snippet20.fs
@@ -1,3 +1,2 @@
-
-    let newList2 = List.map3 (fun x y z -> x + y + z) list1 list2 [2; 3; 4]
-    printfn "%A" newList2
+let newList2 = List.map3 (fun x y z -> x + y + z) list1 list2 [2; 3; 4]
+printfn "%A" newList2

--- a/docs/conceptual/snippets/fslists/snippet21.fs
+++ b/docs/conceptual/snippets/fslists/snippet21.fs
@@ -1,3 +1,2 @@
-
-    let newListAddIndex = List.mapi (fun i x -> x + i) list1
-    printfn "%A" newListAddIndex
+let newListAddIndex = List.mapi (fun i x -> x + i) list1
+printfn "%A" newListAddIndex

--- a/docs/conceptual/snippets/fslists/snippet22.fs
+++ b/docs/conceptual/snippets/fslists/snippet22.fs
@@ -1,3 +1,2 @@
-
-    let listAddTimesIndex = List.mapi2 (fun i x y -> (x + y) * i) list1 list2
-    printfn "%A" listAddTimesIndex
+let listAddTimesIndex = List.mapi2 (fun i x y -> (x + y) * i) list1 list2
+printfn "%A" listAddTimesIndex

--- a/docs/conceptual/snippets/fslists/snippet23.fs
+++ b/docs/conceptual/snippets/fslists/snippet23.fs
@@ -1,3 +1,2 @@
-
 let collectList = List.collect (fun x -> [for i in 1..3 -> x * i]) list1
 printfn "%A" collectList

--- a/docs/conceptual/snippets/fslists/snippet24.fs
+++ b/docs/conceptual/snippets/fslists/snippet24.fs
@@ -1,2 +1,1 @@
-
 let evenOnlyList = List.filter (fun x -> x % 2 = 0) [1; 2; 3; 4; 5; 6]

--- a/docs/conceptual/snippets/fslists/snippet25.fs
+++ b/docs/conceptual/snippets/fslists/snippet25.fs
@@ -1,4 +1,3 @@
-
 let listWords = [ "and"; "Rome"; "Bob"; "apple"; "zebra" ]
 let isCapitalized (string1:string) = System.Char.IsUpper string1.[0]
 let results = List.choose (fun elem ->

--- a/docs/conceptual/snippets/fslists/snippet26.fs
+++ b/docs/conceptual/snippets/fslists/snippet26.fs
@@ -1,4 +1,3 @@
-
 let list1to10 = List.append [1; 2; 3] [4; 5; 6; 7; 8; 9; 10]
 let listResult = List.concat [ [1; 2; 3]; [4; 5; 6]; [7; 8; 9] ]
 List.iter (fun elem -> printf "%d " elem) list1to10

--- a/docs/conceptual/snippets/fslists/snippet27.fs
+++ b/docs/conceptual/snippets/fslists/snippet27.fs
@@ -1,32 +1,31 @@
+let sumList list = List.fold (fun acc elem -> acc + elem) 0 list
+printfn "Sum of the elements of list %A is %d." [ 1 .. 3 ] (sumList [ 1 .. 3 ])
 
-    let sumList list = List.fold (fun acc elem -> acc + elem) 0 list
-    printfn "Sum of the elements of list %A is %d." [ 1 .. 3 ] (sumList [ 1 .. 3 ])
+// The following example computes the average of a list.
+let averageList list = (List.fold (fun acc elem -> acc + float elem) 0.0 list / float list.Length)
 
-    // The following example computes the average of a list.
-    let averageList list = (List.fold (fun acc elem -> acc + float elem) 0.0 list / float list.Length)
+// The following example computes the standard deviation of a list.
+// The standard deviation is computed by taking the square root of the
+// sum of the variances, which are the differences between each value
+// and the average.
+let stdDevList list =
+    let avg = averageList list
+    sqrt (List.fold (fun acc elem -> acc + (float elem - avg) ** 2.0 ) 0.0 list / float list.Length)
 
-    // The following example computes the standard deviation of a list.
-    // The standard deviation is computed by taking the square root of the
-    // sum of the variances, which are the differences between each value
-    // and the average.
-    let stdDevList list =
-        let avg = averageList list
-        sqrt (List.fold (fun acc elem -> acc + (float elem - avg) ** 2.0 ) 0.0 list / float list.Length)
+let testList listTest =
+    printfn "List %A average: %f stddev: %f" listTest (averageList listTest) (stdDevList listTest)
 
-    let testList listTest =
-        printfn "List %A average: %f stddev: %f" listTest (averageList listTest) (stdDevList listTest)
+testList [1; 1; 1]
+testList [1; 2; 1]
+testList [1; 2; 3]
 
-    testList [1; 1; 1]
-    testList [1; 2; 1]
-    testList [1; 2; 3]
+// List.fold is the same as to List.iter when the accumulator is not used.
+let printList list = List.fold (fun acc elem -> printfn "%A" elem) () list
+printList [0.0; 1.0; 2.5; 5.1 ]
 
-    // List.fold is the same as to List.iter when the accumulator is not used.
-    let printList list = List.fold (fun acc elem -> printfn "%A" elem) () list
-    printList [0.0; 1.0; 2.5; 5.1 ]
-
-    // The following example uses List.fold to reverse a list.
-    // The accumulator starts out as the empty list, and the function uses the cons operator
-    // to add each successive element to the head of the accumulator list, resulting in a
-    // reversed form of the list.
-    let reverseList list = List.fold (fun acc elem -> elem::acc) [] list
-    printfn "%A" (reverseList [1 .. 10])
+// The following example uses List.fold to reverse a list.
+// The accumulator starts out as the empty list, and the function uses the cons operator
+// to add each successive element to the head of the accumulator list, resulting in a
+// reversed form of the list.
+let reverseList list = List.fold (fun acc elem -> elem::acc) [] list
+printfn "%A" (reverseList [1 .. 10])

--- a/docs/conceptual/snippets/fslists/snippet28.fs
+++ b/docs/conceptual/snippets/fslists/snippet28.fs
@@ -1,8 +1,7 @@
+// Use List.fold2 to perform computations over two lists (of equal size) at the same time.
+// Example: Sum the greater element at each list position.
+let sumGreatest list1 list2 = List.fold2 (fun acc elem1 elem2 ->
+                                              acc + max elem1 elem2) 0 list1 list2
 
-    // Use List.fold2 to perform computations over two lists (of equal size) at the same time.
-    // Example: Sum the greater element at each list position.
-    let sumGreatest list1 list2 = List.fold2 (fun acc elem1 elem2 ->
-                                                  acc + max elem1 elem2) 0 list1 list2
-
-    let sum = sumGreatest [1; 2; 3] [3; 2; 1]
-    printfn "The sum of the greater of each pair of elements in the two lists is %d." sum
+let sum = sumGreatest [1; 2; 3] [3; 2; 1]
+printfn "The sum of the greater of each pair of elements in the two lists is %d." sum

--- a/docs/conceptual/snippets/fslists/snippet29.fs
+++ b/docs/conceptual/snippets/fslists/snippet29.fs
@@ -1,4 +1,3 @@
-
 // Discriminated union type that encodes the transaction type.
 type Transaction =
     | Deposit

--- a/docs/conceptual/snippets/fslists/snippet3.fs
+++ b/docs/conceptual/snippets/fslists/snippet3.fs
@@ -1,4 +1,3 @@
-
 let isAllZeroes list = List.forall (fun elem -> elem = 0.0) list
 printfn "%b" (isAllZeroes [0.0; 0.0])
 printfn "%b" (isAllZeroes [0.0; 1.0])

--- a/docs/conceptual/snippets/fslists/snippet30.fs
+++ b/docs/conceptual/snippets/fslists/snippet30.fs
@@ -1,4 +1,3 @@
-
 let sumListBack list = List.foldBack (fun acc elem -> acc + elem) list 0
 printfn "%d" (sumListBack [1; 2; 3])
 

--- a/docs/conceptual/snippets/fslists/snippet31.fs
+++ b/docs/conceptual/snippets/fslists/snippet31.fs
@@ -1,4 +1,3 @@
-
 type Transaction2 =
     | Deposit
     | Withdrawal

--- a/docs/conceptual/snippets/fslists/snippet32.fs
+++ b/docs/conceptual/snippets/fslists/snippet32.fs
@@ -1,4 +1,3 @@
-
 // Because foldBack2 processes the lists by starting at end of the list,
 // the interest is calculated first, on the balance of only 200.00.
 let endingBalance3 = List.foldBack2 (fun elem1 elem2 acc ->

--- a/docs/conceptual/snippets/fslists/snippet33.fs
+++ b/docs/conceptual/snippets/fslists/snippet33.fs
@@ -1,4 +1,3 @@
-
 let sumAList list =
     try
         List.reduce (fun acc elem -> acc + elem) list

--- a/docs/conceptual/snippets/fslists/snippet34.fs
+++ b/docs/conceptual/snippets/fslists/snippet34.fs
@@ -1,5 +1,3 @@
-
-
 type Transaction2 =
     | Deposit
     | Withdrawal

--- a/docs/conceptual/snippets/fslists/snippet35.fs
+++ b/docs/conceptual/snippets/fslists/snippet35.fs
@@ -1,5 +1,4 @@
-
-    let list1 = [1; 2; 3]
-    let list2 = [4; 5; 6]
-    let newList = List.map3 (fun x y z -> x + y + z) list1 list2 [2; 3; 4]
-    printfn "%A" newList
+let list1 = [1; 2; 3]
+let list2 = [4; 5; 6]
+let newList = List.map3 (fun x y z -> x + y + z) list1 list2 [2; 3; 4]
+printfn "%A" newList

--- a/docs/conceptual/snippets/fslists/snippet36.fs
+++ b/docs/conceptual/snippets/fslists/snippet36.fs
@@ -1,4 +1,3 @@
-
-    let list1 = [1; 2; 3]
-    let newList = List.mapi (fun i x -> (i, x)) list1
-    printfn "%A" newList
+let list1 = [1; 2; 3]
+let newList = List.mapi (fun i x -> (i, x)) list1
+printfn "%A" newList

--- a/docs/conceptual/snippets/fslists/snippet37.fs
+++ b/docs/conceptual/snippets/fslists/snippet37.fs
@@ -1,5 +1,4 @@
-
-    let list1 = [1; 2; 3]
-    let list2 = [4; 5; 6]
-    let listAddTimesIndex = List.mapi2 (fun i x y -> (x + y) * i) list1 list2
-    printfn "%A" listAddTimesIndex
+let list1 = [1; 2; 3]
+let list2 = [4; 5; 6]
+let listAddTimesIndex = List.mapi2 (fun i x y -> (x + y) * i) list1 list2
+printfn "%A" listAddTimesIndex

--- a/docs/conceptual/snippets/fslists/snippet38.fs
+++ b/docs/conceptual/snippets/fslists/snippet38.fs
@@ -1,4 +1,3 @@
-
-    let listA, listB = List.unzip [(1,2); (3,4)]
-    printfn "%A" listA
-    printfn "%A" listB
+let listA, listB = List.unzip [(1,2); (3,4)]
+printfn "%A" listA
+printfn "%A" listB

--- a/docs/conceptual/snippets/fslists/snippet39.fs
+++ b/docs/conceptual/snippets/fslists/snippet39.fs
@@ -1,3 +1,2 @@
-
-    let listA, listB, listC = List.unzip3 [(1,2,3); (4,5,6)]
-    printfn "%A %A %A" listA listB listC
+let listA, listB, listC = List.unzip3 [(1,2,3); (4,5,6)]
+printfn "%A %A %A" listA listB listC

--- a/docs/conceptual/snippets/fslists/snippet4.fs
+++ b/docs/conceptual/snippets/fslists/snippet4.fs
@@ -1,4 +1,3 @@
-
 let listEqual list1 list2 = List.forall2 (fun elem1 elem2 -> elem1 = elem2) list1 list2
 printfn "%b" (listEqual [0; 1; 2] [0; 1; 2])
 printfn "%b" (listEqual [0; 0; 0] [0; 1; 0])

--- a/docs/conceptual/snippets/fslists/snippet40.fs
+++ b/docs/conceptual/snippets/fslists/snippet40.fs
@@ -1,6 +1,5 @@
-
-    let list1 = [ 1; 2; 3 ]
-    let list2 = [ -1; -2; -3 ]
-    let list3 = [ 0; 0; 0]
-    let listZip3 = List.zip3 list1 list2 list3
-    printfn "%A" listZip3
+let list1 = [ 1; 2; 3 ]
+let list2 = [ -1; -2; -3 ]
+let list3 = [ 0; 0; 0]
+let listZip3 = List.zip3 list1 list2 list3
+printfn "%A" listZip3

--- a/docs/conceptual/snippets/fslists/snippet41.fs
+++ b/docs/conceptual/snippets/fslists/snippet41.fs
@@ -1,9 +1,8 @@
+let sumListBack list = List.foldBack (fun acc elem -> acc + elem) list 0
+printfn "%d" (sumListBack [1; 2; 3])
 
-    let sumListBack list = List.foldBack (fun acc elem -> acc + elem) list 0
-    printfn "%d" (sumListBack [1; 2; 3])
-
-    // For a calculation in which the order of traversal is important, fold and foldBack have different
-    // results. For example, replacing foldBack with fold in the copyList function
-    // produces a function that reverses the list, rather than copying it.
-    let copyList list = List.foldBack (fun elem acc -> elem::acc) list []
-    printfn "%A" (copyList [1 .. 10])
+// For a calculation in which the order of traversal is important, fold and foldBack have different
+// results. For example, replacing foldBack with fold in the copyList function
+// produces a function that reverses the list, rather than copying it.
+let copyList list = List.foldBack (fun elem acc -> elem::acc) list []
+printfn "%A" (copyList [1 .. 10])

--- a/docs/conceptual/snippets/fslists/snippet42.fs
+++ b/docs/conceptual/snippets/fslists/snippet42.fs
@@ -1,4 +1,3 @@
-
-    let list1 = [10; 20; 30]
-    let collectList = List.collect (fun x -> [for i in 1..3 -> x * i]) list1
-    printfn "%A" collectList
+let list1 = [10; 20; 30]
+let collectList = List.collect (fun x -> [for i in 1..3 -> x * i]) list1
+printfn "%A" collectList

--- a/docs/conceptual/snippets/fslists/snippet43.fs
+++ b/docs/conceptual/snippets/fslists/snippet43.fs
@@ -1,5 +1,4 @@
-
-    List.init 10 (fun i -> (i, i * i))
-    |> List.filter (fun (n, nsqr) -> n % 2 = 0)
-    |> List.rev
-    |> List.iter (fun (n, nsqr) -> printfn "(%d, %d) " n nsqr)
+List.init 10 (fun i -> (i, i * i))
+|> List.filter (fun (n, nsqr) -> n % 2 = 0)
+|> List.rev
+|> List.iter (fun (n, nsqr) -> printfn "(%d, %d) " n nsqr)

--- a/docs/conceptual/snippets/fslists/snippet44.fs
+++ b/docs/conceptual/snippets/fslists/snippet44.fs
@@ -1,5 +1,4 @@
-
-    // A generic empty list.
-    let emptyList1 = List.empty
-    // An empty list of a specific type.
-    let emptyList2 = List.empty<int>
+// A generic empty list.
+let emptyList1 = List.empty
+// An empty list of a specific type.
+let emptyList2 = List.empty<int>

--- a/docs/conceptual/snippets/fslists/snippet45.fs
+++ b/docs/conceptual/snippets/fslists/snippet45.fs
@@ -1,12 +1,11 @@
-
-    let list1 = [ 2 .. 100 ]
-    let delta = 1.0e-10
-    let isPerfectSquare (x:int) =
-        let y = sqrt (float x)
-        abs(y - round y) < delta
-    let isPerfectCube (x:int) =
-        let y = System.Math.Pow(float x, 1.0/3.0)
-        abs(y - round y) < delta
-    let element = List.find (fun elem -> isPerfectSquare elem && isPerfectCube elem) list1
-    let index = List.findIndex (fun elem -> isPerfectSquare elem && isPerfectCube elem) list1
-    printfn "The first element that is both a square and a cube is %d and its index is %d." element index
+let list1 = [ 2 .. 100 ]
+let delta = 1.0e-10
+let isPerfectSquare (x:int) =
+    let y = sqrt (float x)
+    abs(y - round y) < delta
+let isPerfectCube (x:int) =
+    let y = System.Math.Pow(float x, 1.0/3.0)
+    abs(y - round y) < delta
+let element = List.find (fun elem -> isPerfectSquare elem && isPerfectCube elem) list1
+let index = List.findIndex (fun elem -> isPerfectSquare elem && isPerfectCube elem) list1
+printfn "The first element that is both a square and a cube is %d and its index is %d." element index

--- a/docs/conceptual/snippets/fslists/snippet46.fs
+++ b/docs/conceptual/snippets/fslists/snippet46.fs
@@ -1,2 +1,1 @@
-
-    printfn "List of squares: %A" (List.init 10 (fun index -> index * index))
+printfn "List of squares: %A" (List.init 10 (fun index -> index * index))

--- a/docs/conceptual/snippets/fslists/snippet47.fs
+++ b/docs/conceptual/snippets/fslists/snippet47.fs
@@ -1,10 +1,9 @@
-
-    let printList list1 = 
-        if (List.isEmpty list1) then
-            printfn "There are no elements in this list."
-        else
-            printfn "This list contains the following elements:"
-            List.iter (fun elem -> printf "%A " elem) list1
-            printfn ""
-    printList [ "test1"; "test2" ]
-    printList [ ]
+let printList list1 = 
+    if (List.isEmpty list1) then
+        printfn "There are no elements in this list."
+    else
+        printfn "This list contains the following elements:"
+        List.iter (fun elem -> printf "%A " elem) list1
+        printfn ""
+printList [ "test1"; "test2" ]
+printList [ ]

--- a/docs/conceptual/snippets/fslists/snippet48.fs
+++ b/docs/conceptual/snippets/fslists/snippet48.fs
@@ -1,4 +1,3 @@
-
-    List.length [ 1 .. 100 ] |> printfn "Length: %d"
-    List.length [ ] |> printfn "Length: %d"
-    List.length [ 1 .. 2 .. 100 ] |> printfn "Length: %d"
+List.length [ 1 .. 100 ] |> printfn "Length: %d"
+List.length [ ] |> printfn "Length: %d"
+List.length [ 1 .. 2 .. 100 ] |> printfn "Length: %d"

--- a/docs/conceptual/snippets/fslists/snippet49.fs
+++ b/docs/conceptual/snippets/fslists/snippet49.fs
@@ -1,4 +1,3 @@
-
-    let list1 = [ -10 .. 10 ]
-    List.nth list1 5
-    |> printfn "The fifth element: %d"
+let list1 = [ -10 .. 10 ]
+List.nth list1 5
+|> printfn "The fifth element: %d"

--- a/docs/conceptual/snippets/fslists/snippet5.fs
+++ b/docs/conceptual/snippets/fslists/snippet5.fs
@@ -1,3 +1,2 @@
-
 let sortedList1 = List.sort [1; 4; 8; -2; 5]
 printfn "%A" sortedList1

--- a/docs/conceptual/snippets/fslists/snippet50.fs
+++ b/docs/conceptual/snippets/fslists/snippet50.fs
@@ -1,4 +1,3 @@
-
-    let list1 = [ 1 .. 10 ]
-    let listEven, listOdd = List.partition (fun elem -> elem % 2 = 0) list1
-    printfn "Evens: %A\nOdds: %A" listEven listOdd
+let list1 = [ 1 .. 10 ]
+let listEven, listOdd = List.partition (fun elem -> elem % 2 = 0) list1
+printfn "Evens: %A\nOdds: %A" listEven listOdd

--- a/docs/conceptual/snippets/fslists/snippet51.fs
+++ b/docs/conceptual/snippets/fslists/snippet51.fs
@@ -1,12 +1,11 @@
-
-    let printPermutation n list1 =
-        let length = List.length list1
-        if (n > 0 && n < length) then
-            List.permute (fun index -> (index + n) % length) list1
-        else
-            list1
-        |> printfn "%A"
-    let list1 = [ 1 .. 5 ]
-    // There are 5 valid permutations of list1, with n from 0 to 4.
-    for n in 0 .. 4 do
-        printPermutation n list1
+let printPermutation n list1 =
+    let length = List.length list1
+    if (n > 0 && n < length) then
+        List.permute (fun index -> (index + n) % length) list1
+    else
+        list1
+    |> printfn "%A"
+let list1 = [ 1 .. 5 ]
+// There are 5 valid permutations of list1, with n from 0 to 4.
+for n in 0 .. 4 do
+    printPermutation n list1

--- a/docs/conceptual/snippets/fslists/snippet52.fs
+++ b/docs/conceptual/snippets/fslists/snippet52.fs
@@ -1,3 +1,2 @@
-
-    let testList = List.replicate 4 "test"
-    printfn "%A" testList
+let testList = List.replicate 4 "test"
+printfn "%A" testList

--- a/docs/conceptual/snippets/fslists/snippet53.fs
+++ b/docs/conceptual/snippets/fslists/snippet53.fs
@@ -1,3 +1,2 @@
-
-    let reverseList = List.rev [ 1 .. 10 ]
-    printfn "%A" reverseList
+let reverseList = List.rev [ 1 .. 10 ]
+printfn "%A" reverseList

--- a/docs/conceptual/snippets/fslists/snippet54.fs
+++ b/docs/conceptual/snippets/fslists/snippet54.fs
@@ -1,11 +1,10 @@
-
-    let initialBalance = 1122.73
-    let transactions = [ -100.00; +450.34; -62.34; -127.00; -13.50; -12.92 ]
-    let balances =
-        List.scan (fun balance transactionAmount -> balance + transactionAmount)
-                  initialBalance transactions
-    printfn "Initial balance:\n $%10.2f" initialBalance
-    printfn "Transaction   Balance"
-    for i in 0 .. List.length transactions - 1 do
-        printfn "$%10.2f $%10.2f" transactions.[i] balances.[i]
-    printfn "Final balance:\n $%10.2f" balances.[ List.length balances - 1]
+let initialBalance = 1122.73
+let transactions = [ -100.00; +450.34; -62.34; -127.00; -13.50; -12.92 ]
+let balances =
+    List.scan (fun balance transactionAmount -> balance + transactionAmount)
+              initialBalance transactions
+printfn "Initial balance:\n $%10.2f" initialBalance
+printfn "Transaction   Balance"
+for i in 0 .. List.length transactions - 1 do
+    printfn "$%10.2f $%10.2f" transactions.[i] balances.[i]
+printfn "Final balance:\n $%10.2f" balances.[ List.length balances - 1]

--- a/docs/conceptual/snippets/fslists/snippet55.fs
+++ b/docs/conceptual/snippets/fslists/snippet55.fs
@@ -1,4 +1,3 @@
-
-    [ for x in -100 .. 100 -> 4 - x * x ]
-    |> List.max
-    |> printfn "%A"
+[ for x in -100 .. 100 -> 4 - x * x ]
+|> List.max
+|> printfn "%A"

--- a/docs/conceptual/snippets/fslists/snippet56.fs
+++ b/docs/conceptual/snippets/fslists/snippet56.fs
@@ -1,4 +1,3 @@
-
-    [ -10.0 .. 10.0 ]
-    |> List.maxBy (fun x -> 1.0 - x * x)
-    |> printfn "%A"
+[ -10.0 .. 10.0 ]
+|> List.maxBy (fun x -> 1.0 - x * x)
+|> printfn "%A"

--- a/docs/conceptual/snippets/fslists/snippet57.fs
+++ b/docs/conceptual/snippets/fslists/snippet57.fs
@@ -1,4 +1,3 @@
-
-    [ for x in -100 .. 100 -> x * x - 4 ]
-    |> List.min
-    |> printfn "%A" 
+[ for x in -100 .. 100 -> x * x - 4 ]
+|> List.min
+|> printfn "%A" 

--- a/docs/conceptual/snippets/fslists/snippet58.fs
+++ b/docs/conceptual/snippets/fslists/snippet58.fs
@@ -1,4 +1,3 @@
-
-    [ -10.0 .. 10.0 ]
-    |> List.minBy (fun x -> x * x - 1.0)
-    |> printfn "%A"
+[ -10.0 .. 10.0 ]
+|> List.minBy (fun x -> x * x - 1.0)
+|> printfn "%A"

--- a/docs/conceptual/snippets/fslists/snippet59.fs
+++ b/docs/conceptual/snippets/fslists/snippet59.fs
@@ -1,2 +1,1 @@
-
-    let list1 = List.ofArray [| 1 .. 10 |]
+let list1 = List.ofArray [| 1 .. 10 |]

--- a/docs/conceptual/snippets/fslists/snippet6.fs
+++ b/docs/conceptual/snippets/fslists/snippet6.fs
@@ -1,3 +1,2 @@
-
 let sortedList2 = List.sortBy (fun elem -> abs elem) [1; 4; 8; -2; 5]
 printfn "%A" sortedList2

--- a/docs/conceptual/snippets/fslists/snippet60.fs
+++ b/docs/conceptual/snippets/fslists/snippet60.fs
@@ -1,2 +1,1 @@
-
-    let list1 = List.ofSeq ( seq { 1 .. 10 } )
+let list1 = List.ofSeq ( seq { 1 .. 10 } )

--- a/docs/conceptual/snippets/fslists/snippet61.fs
+++ b/docs/conceptual/snippets/fslists/snippet61.fs
@@ -1,33 +1,32 @@
+// A list of functions that transform 
+// integers. (int -> int)
+let ops1 =
+  [ (fun x -> x + 1), "add 1"
+    (fun x -> x + 2), "add 2"
+    (fun x -> x - 5), "subtract 5" ]
 
-    // A list of functions that transform 
-    // integers. (int -> int)
-    let ops1 =
-     [ (fun x -> x + 1), "add 1"
-       (fun x -> x + 2), "add 2"
-       (fun x -> x - 5), "subtract 5" ]
+let ops2 =
+  [ (fun x -> x + 1), "add 1"
+    (fun x -> x * 5), "multiply by 5"
+    (fun x -> x * x), "square" ]
 
-    let ops2 =
-     [ (fun x -> x + 1), "add 1"
-       (fun x -> x * 5), "multiply by 5"
-       (fun x -> x * x), "square" ]
+// Compare scan and scanBack, which apply the
+// operations in the opposite order.
+let compareOpOrder ops x0 =
+    let ops, opNames = List.unzip ops
+    let xs1 = List.scan (fun x op -> op x) x0 ops
+    let xs2 = List.scanBack (fun op x -> op x) ops x0
 
-    // Compare scan and scanBack, which apply the
-    // operations in the opposite order.
-    let compareOpOrder ops x0 =
-        let ops, opNames = List.unzip ops
-        let xs1 = List.scan (fun x op -> op x) x0 ops
-        let xs2 = List.scanBack (fun op x -> op x) ops x0
+    printfn "Operations:"
+    opNames |> List.iter (fun opName -> printf "%s  " opName)
+    printfn ""
 
-        printfn "Operations:"
-        opNames |> List.iter (fun opName -> printf "%s  " opName)
-        printfn ""
+    // Print the intermediate results.
+    let xs = List.zip xs1 (List.rev xs2)
+    printfn "List.scan List.scanBack"
+    for (x1, x2) in xs do
+        printfn "%10d %10d" x1 x2
+    printfn ""
 
-        // Print the intermediate results.
-        let xs = List.zip xs1 (List.rev xs2)
-        printfn "List.scan List.scanBack"
-        for (x1, x2) in xs do
-            printfn "%10d %10d" x1 x2
-        printfn ""
-
-    compareOpOrder ops1 10
-    compareOpOrder ops2 10
+compareOpOrder ops1 10
+compareOpOrder ops2 10

--- a/docs/conceptual/snippets/fslists/snippet62.fs
+++ b/docs/conceptual/snippets/fslists/snippet62.fs
@@ -1,15 +1,14 @@
+open System
 
-    open System
-
-    let list1 = [ "<>"; "&"; "&&"; "&&&"; "<"; ">"; "|"; "||"; "|||" ]
-    printfn "Before sorting: "
-    list1 |> printfn "%A"
-    let sortFunction (string1:string) (string2:string) =
-        if (string1.Length > string2.Length) then
-           1
-        else if (string1.Length < string2.Length) then
-           -1
-        else
-            String.Compare(string1, string2)
-    List.sortWith sortFunction list1
-    |> printfn "After sorting:\n%A"
+let list1 = [ "<>"; "&"; "&&"; "&&&"; "<"; ">"; "|"; "||"; "|||" ]
+printfn "Before sorting: "
+list1 |> printfn "%A"
+let sortFunction (string1:string) (string2:string) =
+    if (string1.Length > string2.Length) then
+        1
+    else if (string1.Length < string2.Length) then
+        -1
+    else
+        String.Compare(string1, string2)
+List.sortWith sortFunction list1
+|> printfn "After sorting:\n%A"

--- a/docs/conceptual/snippets/fslists/snippet63.fs
+++ b/docs/conceptual/snippets/fslists/snippet63.fs
@@ -1,7 +1,6 @@
-
-    let list1 = [1; 2; 3]
-    let list2 = []
-    // The following line prints [2; 3].
-    printfn "%A" (List.tail list1)
-    // The following line throws System.ArgumentException.
-    printfn "%A" (List.tail list2)
+let list1 = [1; 2; 3]
+let list2 = []
+// The following line prints [2; 3].
+printfn "%A" (List.tail list1)
+// The following line throws System.ArgumentException.
+printfn "%A" (List.tail list2)

--- a/docs/conceptual/snippets/fslists/snippet64.fs
+++ b/docs/conceptual/snippets/fslists/snippet64.fs
@@ -1,6 +1,5 @@
-
-    let array1 = [ 1; 3; -2; 4 ]
-                 |> List.toArray
-    Array.set array1 3 -10
-    Array.sortInPlaceWith (fun elem1 elem2 -> compare elem1 elem2) array1
-    printfn "%A" array1
+let array1 = [ 1; 3; -2; 4 ]
+              |> List.toArray
+Array.set array1 3 -10
+Array.sortInPlaceWith (fun elem1 elem2 -> compare elem1 elem2) array1
+printfn "%A" array1

--- a/docs/conceptual/snippets/fslists/snippet65.fs
+++ b/docs/conceptual/snippets/fslists/snippet65.fs
@@ -1,32 +1,31 @@
+let findPerfectSquareAndCube list1 =
+    let delta = 1.0e-10
+    let isPerfectSquare (x:int) =
+        let y = sqrt (float x)
+        abs(y - round y) < delta
+    let isPerfectCube (x:int) =
+        let y = System.Math.Pow(float x, 1.0/3.0)
+        abs(y - round y) < delta
+    // intFunction : (float -> float) -> int -> int
+    // Allows the use of a floating point function with integers.
+    let intFunction function1 number = int (round (function1 (float number)))
+    let cubeRoot x = System.Math.Pow(x, 1.0/3.0)
+    // testElement: int -> (int * int * int) option
+    // Test an element to see whether it is a perfect square and a perfect
+    // cube, and, if so, return the element, square root, and cube root
+    // as an option value. Otherwise, return None.
+    let testElement elem = 
+        if isPerfectSquare elem && isPerfectCube elem then
+            Some(elem, intFunction sqrt elem, intFunction cubeRoot elem)
+        else None
+    match List.tryPick testElement list1 with
+    | Some (n, sqrt, cuberoot) ->
+        printfn "Found an element %d with square root %d and cube root %d." n sqrt cuberoot
+    | None ->
+        printfn "Did not find an element that is both a perfect square and a perfect cube."
 
-    let findPerfectSquareAndCube list1 =
-        let delta = 1.0e-10
-        let isPerfectSquare (x:int) =
-            let y = sqrt (float x)
-            abs(y - round y) < delta
-        let isPerfectCube (x:int) =
-            let y = System.Math.Pow(float x, 1.0/3.0)
-            abs(y - round y) < delta
-        // intFunction : (float -> float) -> int -> int
-        // Allows the use of a floating point function with integers.
-        let intFunction function1 number = int (round (function1 (float number)))
-        let cubeRoot x = System.Math.Pow(x, 1.0/3.0)
-        // testElement: int -> (int * int * int) option
-        // Test an element to see whether it is a perfect square and a perfect
-        // cube, and, if so, return the element, square root, and cube root
-        // as an option value. Otherwise, return None.
-        let testElement elem = 
-            if isPerfectSquare elem && isPerfectCube elem then
-                Some(elem, intFunction sqrt elem, intFunction cubeRoot elem)
-            else None
-        match List.tryPick testElement list1 with
-        | Some (n, sqrt, cuberoot) ->
-            printfn "Found an element %d with square root %d and cube root %d." n sqrt cuberoot
-        | None ->
-            printfn "Did not find an element that is both a perfect square and a perfect cube."
-
-    findPerfectSquareAndCube [ 1 .. 10 ]
-    findPerfectSquareAndCube [ 2 .. 100 ]
-    findPerfectSquareAndCube [ 100 .. 1000 ]
-    findPerfectSquareAndCube [ 1000 .. 10000 ]
-    findPerfectSquareAndCube [ 2 .. 50 ]
+findPerfectSquareAndCube [ 1 .. 10 ]
+findPerfectSquareAndCube [ 2 .. 100 ]
+findPerfectSquareAndCube [ 100 .. 1000 ]
+findPerfectSquareAndCube [ 1000 .. 10000 ]
+findPerfectSquareAndCube [ 2 .. 50 ]

--- a/docs/conceptual/snippets/fslists/snippet66.fs
+++ b/docs/conceptual/snippets/fslists/snippet66.fs
@@ -1,4 +1,3 @@
-
-    [ 1 .. 10 ]
-    |> List.sum
-    |> printfn "Sum: %d"
+[ 1 .. 10 ]
+|> List.sum
+|> printfn "Sum: %d"

--- a/docs/conceptual/snippets/fslists/snippet67.fs
+++ b/docs/conceptual/snippets/fslists/snippet67.fs
@@ -1,4 +1,3 @@
-
-    [ 1 .. 10 ]
-    |> List.sumBy (fun x -> x * x)
-    |> printfn "Sum: %d"
+[ 1 .. 10 ]
+|> List.sumBy (fun x -> x * x)
+|> printfn "Sum: %d"

--- a/docs/conceptual/snippets/fslists/snippet68.fs
+++ b/docs/conceptual/snippets/fslists/snippet68.fs
@@ -1,6 +1,5 @@
-
-    [ 1 .. 10 ]
-    |> List.toSeq
-    |> Seq.truncate 5
-    |> Seq.iter (fun elem -> printf "%d " elem)
-    printfn ""
+[ 1 .. 10 ]
+|> List.toSeq
+|> Seq.truncate 5
+|> Seq.iter (fun elem -> printf "%d " elem)
+printfn ""

--- a/docs/conceptual/snippets/fslists/snippet7.fs
+++ b/docs/conceptual/snippets/fslists/snippet7.fs
@@ -1,4 +1,3 @@
-
 type Widget = { ID: int; Rev: int }
 
 let compareWidgets widget1 widget2 =

--- a/docs/conceptual/snippets/fslists/snippet8.fs
+++ b/docs/conceptual/snippets/fslists/snippet8.fs
@@ -1,4 +1,3 @@
-
 let isDivisibleBy number elem = elem % number = 0
 let result = List.find (isDivisibleBy 5) [ 1 .. 100 ]
 printfn "%d " result

--- a/docs/conceptual/snippets/fslists/snippet9.fs
+++ b/docs/conceptual/snippets/fslists/snippet9.fs
@@ -1,4 +1,3 @@
-
 let valuesList = [ ("a", 1); ("b", 2); ("c", 3) ]
 
 let resultPick = List.pick (fun elem ->


### PR DESCRIPTION
fixed indentation and prefix empty lines in snippets for list.

Please review the diff by adding `&w=1` to the URI.