### PR TITLE
Map addition: documented behavior for present keys, fixed formatting

### DIFF
--- a/docs/conceptual/map.add['key,'t]-function-[fsharp].md
+++ b/docs/conceptual/map.add['key,'t]-function-[fsharp].md
@@ -62,7 +62,7 @@ This function is named **Add** in compiled assemblies. If you are accessing the 
 
 [!code-fsharp[Main](snippets/fsmaps/snippet1.fs)]
 
-**Output:**
+**Output**
 
 ```
 key: 0 value: zero

--- a/docs/conceptual/map.add['key,'t]-function-[fsharp].md
+++ b/docs/conceptual/map.add['key,'t]-function-[fsharp].md
@@ -12,7 +12,7 @@ ms.assetid: 79958b34-af76-4dd4-941e-85ecc56c251c
 
 # Map.add<'Key,'T> Function (F#)
 
-Returns a new map with the binding added to the given map.
+Returns a new map from a given map, with an additional or replaced binding.
 
 **Namespace/Module Path**: Microsoft.FSharp.Collections.Map
 
@@ -33,13 +33,11 @@ Map.add key value table
 *key*
 Type: **'Key**
 
-
 The input key.
 
 
 *value*
 Type: **'T**
-
 
 The input value.
 
@@ -47,22 +45,32 @@ The input value.
 *table*
 Type: [Map](https://msdn.microsoft.com/library/975316ea-55e3-4987-9994-90897ad45664)**&lt;'Key,'T&gt;**
 
-
 The input map.
 
 
+## Return Value
 
-**The resulting map.**
+The resulting map, in which the given key maps to the given value. If the key of the newly added key-value pair is present in *table*, the newly added pair replaces the old pair in the resulting map.
+
+
 ## Remarks
+
 This function is named **Add** in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.
 
-**The following code example shows how to use Map.add.**
+
+## Example
+
 [!code-fsharp[Main](snippets/fsmaps/snippet1.fs)]
-**Output**
-**key: 0 value: zero**
-**key: 1 value: one**
-**key: 2 value: two**
-**key: 3 value: three**
+
+**Output:**
+
+```
+key: 0 value: zero
+key: 1 value: one
+key: 2 value: twice
+```
+
+
 ## Platforms
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
@@ -73,10 +81,7 @@ Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 Supported in: 2.0, 4.0, Portable
 
 
-
-
 ## See Also
 [Collections.Map Module &#40;F&#35;&#41;](Collections.Map-Module-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Collections Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Collections-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/map.add['key,'value]-method-[fsharp].md
+++ b/docs/conceptual/map.add['key,'value]-method-[fsharp].md
@@ -55,8 +55,8 @@ The resulting map, in which the given key maps to the given value. If the key of
 
 ```
 key: 0 value: zero
-key: 1 value: twice
-key: 2 value: two
+key: 1 value: one
+key: 2 value: twice
 ```
 
 

--- a/docs/conceptual/map.add['key,'value]-method-[fsharp].md
+++ b/docs/conceptual/map.add['key,'value]-method-[fsharp].md
@@ -12,11 +12,11 @@ ms.assetid: f85baaff-bcd7-464b-959f-f5b502e9cebb
 
 # Map.Add<'Key,'Value> Method (F#)
 
-Returns a new map with the binding added to the given map.
+Returns a new map from a given map, with an additional or replaced binding.
 
-**Namespace/Module Path:** Microsoft.FSharp.Collections
+**Namespace/Module Path**: Microsoft.FSharp.Collections
 
-**Assembly:** FSharp.Core (in FSharp.Core.dll)
+**Assembly**: FSharp.Core (in FSharp.Core.dll)
 
 
 ## Syntax
@@ -33,27 +33,33 @@ map.Add (key, value)
 *key*
 Type: **'Key**
 
-
 The input key.
 
 
 *value*
 Type: **'Value**
 
-
 The input value.
 
 
+## Return Value
 
-**The resulting map.**
-## Remarks
-**The following code example shows how to use the Add method.**
+The resulting map, in which the given key maps to the given value. If the key of the newly added key-value pair is present in the map this method was called on, the newly added pair replaces the old pair in the resulting map.
+
+
+## Example
+
 [!code-fsharp[Main](snippets/fsmaps/snippet2.fs)]
+
 **Output**
-**key: 0 value: zero**
-**key: 1 value: one**
-**key: 2 value: two**
-**key: 3 value: three**
+
+```
+key: 0 value: zero
+key: 1 value: twice
+key: 2 value: two
+```
+
+
 ## Platforms
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
@@ -64,10 +70,7 @@ Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 Supported in: 2.0, 4.0, Portable
 
 
-
-
 ## See Also
 [Collections.Map&#60;'Key,'Value&#62; Class &#40;F&#35;&#41;](Collections.Map%5B%27Key%2C%27Value%5D-Class-%5BFSharp%5D.md)
 
 [Microsoft.FSharp.Collections Namespace &#40;F&#35;&#41;](Microsoft.FSharp.Collections-Namespace-%5BFSharp%5D.md)
-

--- a/docs/conceptual/snippets/fsmaps/snippet1.fs
+++ b/docs/conceptual/snippets/fsmaps/snippet1.fs
@@ -1,4 +1,4 @@
-
-    Map.ofList [ (1, "one"); (2, "two"); (3, "three") ]
-    |> Map.add(0) "zero"
+    Map.ofList [ (1, "one"); (2, "two") ]
+    |> Map.add 0 "zero"
+    |> Map.add 3 "twice"
     |> Map.iter (fun key value -> printfn "key: %d value: %s" key value)

--- a/docs/conceptual/snippets/fsmaps/snippet1.fs
+++ b/docs/conceptual/snippets/fsmaps/snippet1.fs
@@ -1,4 +1,4 @@
     Map.ofList [ (1, "one"); (2, "two") ]
     |> Map.add 0 "zero"
-    |> Map.add 3 "twice"
+    |> Map.add 2 "twice"
     |> Map.iter (fun key value -> printfn "key: %d value: %s" key value)

--- a/docs/conceptual/snippets/fsmaps/snippet2.fs
+++ b/docs/conceptual/snippets/fsmaps/snippet2.fs
@@ -1,4 +1,4 @@
-
-    let map1 = Map.ofList [ (1, "one"); (2, "two"); (3, "three") ]
+    let map1 = Map.ofList [ (1, "one"); (2, "two") ]
     let map2 = map1.Add(0, "zero")
-    map2 |> Map.iter (fun key value -> printfn "key: %d value: %s" key value)
+    let map3 = map2.Add(1, "twice")
+    map3 |> Map.iter (fun key value -> printfn "key: %d value: %s" key value)

--- a/docs/conceptual/snippets/fsmaps/snippet2.fs
+++ b/docs/conceptual/snippets/fsmaps/snippet2.fs
@@ -1,4 +1,4 @@
     let map1 = Map.ofList [ (1, "one"); (2, "two") ]
     let map2 = map1.Add(0, "zero")
-    let map3 = map2.Add(1, "twice")
+    let map3 = map2.Add(2, "twice")
     map3 |> Map.iter (fun key value -> printfn "key: %d value: %s" key value)


### PR DESCRIPTION
Hi! This is my first PR on Github, so please give me a heads up if there's something that should be done differently.

I changed the documentation of Map.add and Map.Add to specify what happens if a key is already present, altered the examples to show what happens in this case, and edited the formatting to look less broken. I hope that's useful.

(Technically, this changes the behavior for present keys from unspecified specified. Is there an actual specification of what these methods should do? In the case of a key that is already present, it's highly unlikely that the behavior will change in the future, but there are other functions where I'm not so sure.)