### PR TITLE
OverflowException on Array.sum and + typo on Operators.Checked

### DIFF
--- a/docs/conceptual/array.sum[^t]-function-[fsharp].md
+++ b/docs/conceptual/array.sum[^t]-function-[fsharp].md
@@ -14,9 +14,9 @@ ms.assetid: 532a4929-def0-4095-8c62-3bc7312038f2
 
 Returns the sum of the elements in the array.
 
-**Namespace/Module Path:** Microsoft.FSharp.Collections.Array
+**Namespace/Module Path**: Microsoft.FSharp.Collections.Array
 
-**Assembly:** FSharp.Core (in FSharp.Core.dll)
+**Assembly**: FSharp.Core (in FSharp.Core.dll)
 
 
 ## Syntax
@@ -30,22 +30,32 @@ Array.sum array
 ```
 
 #### Parameters
-*array*
-Type: **^T**[[]](https://msdn.microsoft.com/library/def20292-9aae-4596-9275-b94e594f8493)
-
+*array* Type: **^T**[[]](https://msdn.microsoft.com/library/def20292-9aae-4596-9275-b94e594f8493)
 
 The input array.
 
 
+## Return Value
 
-**The resulting sum.**
+The resulting sum.
+
+
 ## Remarks
+The function executes addition via the [checked (+) operator](https://msdn.microsoft.com/visualfsharpdocs/conceptual/checked.[-p-][%5Et1%2c%5Et2%2c%5Et3]-function-[fsharp]) and may throw an [OverflowException](https://msdn.microsoft.com/library/system.overflowexception(v=vs.110).aspx) accordingly.
+
 This function is named **Sum** in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.
 
-**The following code shows how to use Array.sum.**
+
+## Example
 [!code-fsharp[Main](snippets/fsarrays/snippet66.fs)]
+
 **Output**
-**55**
+
+```
+55
+```
+
+
 ## Platforms
 Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 
@@ -54,8 +64,6 @@ Windows 8, Windows 7, Windows Server 2012, Windows Server 2008 R2
 **F# Core Library Versions**
 
 Supported in: 2.0, 4.0, Portable
-
-
 
 
 ## See Also

--- a/docs/conceptual/array.sum[^t]-function-[fsharp].md
+++ b/docs/conceptual/array.sum[^t]-function-[fsharp].md
@@ -14,9 +14,9 @@ ms.assetid: 532a4929-def0-4095-8c62-3bc7312038f2
 
 Returns the sum of the elements in the array.
 
-**Namespace/Module Path**: Microsoft.FSharp.Collections.Array
+**Namespace/Module Path:** Microsoft.FSharp.Collections.Array
 
-**Assembly**: FSharp.Core (in FSharp.Core.dll)
+**Assembly:** FSharp.Core (in FSharp.Core.dll)
 
 
 ## Syntax
@@ -41,7 +41,7 @@ The resulting sum.
 
 
 ## Remarks
-May throw an [OverflowException](https://msdn.microsoft.com/library/system.overflowexception(v=vs.110).aspx), as the function uses the [checked (+) operator](https://msdn.microsoft.com/visualfsharpdocs/conceptual/checked.[-p-][%5Et1%2c%5Et2%2c%5Et3]-function-[fsharp]) for the additions.
+May throw an [OverflowException](https://msdn.microsoft.com/library/system.overflowexception.aspx), as the function uses the [checked (+) operator](https://msdn.microsoft.com/visualfsharpdocs/conceptual/checked.[-p-][%5Et1%2c%5Et2%2c%5Et3]-function-[fsharp]) for the additions.
 
 This function is named **Sum** in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.
 

--- a/docs/conceptual/array.sum[^t]-function-[fsharp].md
+++ b/docs/conceptual/array.sum[^t]-function-[fsharp].md
@@ -41,7 +41,7 @@ The resulting sum.
 
 
 ## Remarks
-The function executes addition via the [checked (+) operator](https://msdn.microsoft.com/visualfsharpdocs/conceptual/checked.[-p-][%5Et1%2c%5Et2%2c%5Et3]-function-[fsharp]) and may throw an [OverflowException](https://msdn.microsoft.com/library/system.overflowexception(v=vs.110).aspx) accordingly.
+May throw an [OverflowException](https://msdn.microsoft.com/library/system.overflowexception(v=vs.110).aspx), as the function uses the [checked (+) operator](https://msdn.microsoft.com/visualfsharpdocs/conceptual/checked.[-p-][%5Et1%2c%5Et2%2c%5Et3]-function-[fsharp]) for the additions.
 
 This function is named **Sum** in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.
 

--- a/docs/conceptual/array.sum[^t]-function-[fsharp].md
+++ b/docs/conceptual/array.sum[^t]-function-[fsharp].md
@@ -40,9 +40,11 @@ The input array.
 The resulting sum.
 
 
-## Remarks
+## Exceptions
 May throw an [OverflowException](https://msdn.microsoft.com/library/system.overflowexception.aspx), as the function uses the [checked (+) operator](https://msdn.microsoft.com/visualfsharpdocs/conceptual/checked.[-p-][%5Et1%2c%5Et2%2c%5Et3]-function-[fsharp]) for the additions.
 
+
+## Remarks
 This function is named **Sum** in compiled assemblies. If you are accessing the function from a language other than F#, or through reflection, use this name.
 
 

--- a/docs/conceptual/map.add['key,'t]-function-[fsharp].md
+++ b/docs/conceptual/map.add['key,'t]-function-[fsharp].md
@@ -14,9 +14,9 @@ ms.assetid: 79958b34-af76-4dd4-941e-85ecc56c251c
 
 Returns a new map from a given map, with an additional or replaced binding.
 
-**Namespace/Module Path**: Microsoft.FSharp.Collections.Map
+**Namespace/Module Path:** Microsoft.FSharp.Collections.Map
 
-**Assembly**: FSharp.Core (in FSharp.Core.dll)
+**Assembly:** FSharp.Core (in FSharp.Core.dll)
 
 
 ## Syntax

--- a/docs/conceptual/map.add['key,'value]-method-[fsharp].md
+++ b/docs/conceptual/map.add['key,'value]-method-[fsharp].md
@@ -14,9 +14,9 @@ ms.assetid: f85baaff-bcd7-464b-959f-f5b502e9cebb
 
 Returns a new map from a given map, with an additional or replaced binding.
 
-**Namespace/Module Path**: Microsoft.FSharp.Collections
+**Namespace/Module Path:** Microsoft.FSharp.Collections
 
-**Assembly**: FSharp.Core (in FSharp.Core.dll)
+**Assembly:** FSharp.Core (in FSharp.Core.dll)
 
 
 ## Syntax

--- a/docs/conceptual/operators.checked-module-[fsharp].md
+++ b/docs/conceptual/operators.checked-module-[fsharp].md
@@ -33,7 +33,7 @@ module Checked
 |Value|Description|
 |-----|-----------|
 |[( &#42; )](https://msdn.microsoft.com/library/8a3edb1d-f221-4393-b64b-4e790e177b55)<br />**: ^T1 -&gt; ^T2 -&gt; ^T3**|Overloaded multiplication operator (checks for overflow).|
-|[( - )](https://msdn.microsoft.com/library/e33c5aea-8454-4fba-b471-1e833e21d3ea)<br />**: ^T1 -&gt; 'T2 -&gt; 'T3**|Overloaded addition operator (checks for overflow).|
+|[( + )](https://msdn.microsoft.com/library/e33c5aea-8454-4fba-b471-1e833e21d3ea)<br />**: ^T1 -&gt; 'T2 -&gt; 'T3**|Overloaded addition operator (checks for overflow).|
 |[( - )](https://msdn.microsoft.com/library/7c16d973-2ab5-4689-8f01-2fd3a79fe536)<br />**: ^T1 -&gt; ^T2 -&gt; ^T3**|Overloaded subtraction operator (checks for overflow).|
 |[( ~- )](https://msdn.microsoft.com/library/4fa7cd12-8c9f-495f-8741-e5da3d28fd19)<br />**: ^T -&gt; ^T**|Overloaded unary negation (checks for overflow).|
 |[byte](https://msdn.microsoft.com/library/31fafa71-165c-4d79-9e99-551a0334cd4b)<br />**: ^T -&gt; byte**|Converts the argument to **byte**. This is a direct, checked conversion for all primitive numeric types. For strings, the input is converted using **M:System.Byte.Parse(System.String)** with **P:System.Globalization.CultureInfo.InvariantCulture** settings. Otherwise the operation requires an appropriate static conversion method on the input type.|

--- a/docs/conceptual/snippets/fsarrays/snippet66.fs
+++ b/docs/conceptual/snippets/fsarrays/snippet66.fs
@@ -1,4 +1,3 @@
-
-    [| 1 .. 10 |]
-    |> Array.sum
-    |> printfn "Sum: %d"
+[| 1 .. 10 |]
+|> Array.sum
+|> printfn "Sum: %d"


### PR DESCRIPTION
This OverflowException is actually undocumented behavior on Array.sumBy, List.sum, List.sumBy, Seq.sum, and Seq.sumBy as well, but I'd prefer if everyone agrees on how to document this before someone might have to edit all these files multiple times.

**I'm making two assumptions here, on things I technically don't know:** that overflow behavior is specified, as in not undefined behavior, and that its implementation via Operators.Checked is part of this defined behavior. This feels like the most economical way to define and document the exact throwing behavior and aligns with the F# library's usual policy of avoiding breaking changes. If this is wrong, please tell me how I can determine what things are *supposed to do*, because if I'm editing the only documentation I know, I'm effectively specifying the correct behavior.

When adding links, I ran across the + operator being called - in the Operators.Checked module doc, so I fixed this as well. (I see someone *just* fixed the equivalent issue on the "normal" operators. :) )

The other changes should be minor, they're only to regularize formatting.