### PR TITLE
Moved #nowarn example into table cell.

### DIFF
--- a/docs/conceptual/compiler-directives-[fsharp].md
+++ b/docs/conceptual/compiler-directives-[fsharp].md
@@ -28,11 +28,8 @@ The following table lists the preprocessor directives that are available in F#.
 |**#else**|Supports conditional compilation. Marks a section of code to include if the symbol used with the previous **#if** is not defined.|
 |**#endif**|Supports conditional compilation. Marks the end of a conditional section of code.|
 |**#**[line] *int*, **#**[line] *int**string*, **#**[line] *int**verbatim-string*|Indicates the original source code line and file name, for debugging. This feature is provided for tools that generate F# source code.|
-|**#nowarn***warningcode*|Disables a compiler warning or warnings. To disable a warning, find its number from the compiler output and include it in quotation marks. Omit the "FS" prefix. To disable multiple warning numbers on the same line, include each number in quotation marks, and separate each string by a space. For example:<br /><br /><br />
+|**#nowarn***warningcode*|Disables a compiler warning or warnings. To disable a warning, find its number from the compiler output and include it in quotation marks. Omit the "FS" prefix. To disable multiple warning numbers on the same line, include each number in quotation marks, and separate each string by a space. For example:<br /><br />`#nowarn "9" "40"`<br />
 
-```
-f#<br />#nowarn "9" "40"<br />
-```
 
 <br />The effect of disabling a warning applies to the entire file, including portions of the file that precede the directive.|
 


### PR DESCRIPTION
As far as I can tell, using [MarkdownPad2](http://markdownpad.com) locally, you can't have multiple lines in a Markdown table. It looks like you can cheat by inlining the example with `<br />` tags, which is what I've done here. This precludes the use of multi-line code blocks, however, but fortunately, in this case, a single line of example is all that's required.

In order to explain what this pull request attempts to address, here's a screen shot of how the `#nowarn` example currently looks on MSDN:

![image](https://cloud.githubusercontent.com/assets/242165/15632000/047ee33a-2584-11e6-8f84-413190020a5e.png)

Notice that the example comes after the table, although it ought to belong to the cell explaining how `#nowarn` works. Additionally, it's surrounded by HTML tags.