### PR TITLE
Corrected indentation of text.

### DIFF
--- a/docs/conceptual/interfaces-[fsharp].md
+++ b/docs/conceptual/interfaces-[fsharp].md
@@ -57,7 +57,8 @@ The .NET coding style is to begin all interfaces with a capital **I**.
 You can implement one or more interfaces in a class type by using the **interface** keyword, the name of the interface, and the **with** keyword, followed by the interface member definitions, as shown in the following code.
 
 [!code-fsharp[Main](snippets/fslangref1/snippet2801.fs)]
-    Interface implementations are inherited, so any derived classes do not need to reimplement them.
+
+Interface implementations are inherited, so any derived classes do not need to reimplement them.
 
 
 ## Calling Interface Methods
@@ -66,7 +67,8 @@ Interface methods can be called only through the interface, not through any obje
 To call the interface method when you have an object of type **SomeClass**, you must upcast the object to the interface type, as shown in the following code.
 
 [!code-fsharp[Main](snippets/fslangref1/snippet2802.fs)]
-    An alternative is to declare a method on the object that upcasts and calls the interface method, as in the following example.
+
+An alternative is to declare a method on the object that upcasts and calls the interface method, as in the following example.
 
 [!code-fsharp[Main](snippets/fslangref1/snippet2803.fs)]
     


### PR DESCRIPTION
When the text is indented, the renderer interprets it as a code snippet,
and renders it in a box and monospaced font. These two paragraphs look
like prose to me, so I corrected the indentation.

Here's an example of how it looks at the moment on MSDN:

![image](https://cloud.githubusercontent.com/assets/242165/15805852/372279fc-2b36-11e6-916e-fc80c7c5815d.png)
