### PR TITLE
Fixed formatting issues

### DIFF
--- a/docs/conceptual/code-quotations-[fsharp].md
+++ b/docs/conceptual/code-quotations-[fsharp].md
@@ -17,7 +17,7 @@ This topic describes *code quotations*, a language feature that enables you to g
 
 
 ## Quoted Expressions
-A *quoted expression* is an F# expression in your code that is delimited in such a way that it is not compiled as part of your program, but instead is compiled into an object that represents an F# expression. You can mark a quoted expression in one of two ways: either with type information or without type information. If you want to include type information, you use the symbols **&lt;@** and **@&gt;** to delimit the quoted expression. If you do not need type information, you use the symbols `<@@` and `@@>`. The following code shows typed and untyped quotations.
+A *quoted expression* is an F# expression in your code that is delimited in such a way that it is not compiled as part of your program, but instead is compiled into an object that represents an F# expression. You can mark a quoted expression in one of two ways: either with type information or without type information. If you want to include type information, you use the symbols `<@` and `@>` to delimit the quoted expression. If you do not need type information, you use the symbols `<@@` and `@@>`. The following code shows typed and untyped quotations.
 
 [!code-fsharp[Main](snippets/fslangref3/snippet501.fs)]
 


### PR DESCRIPTION
Changed it to use the back-quotes to match the same format as the untyped quotations, besides fixing the issue that was rendering `**&lt;@**` as **&amp;lt@**