### PR TITLE
Fix display issue with the double bar operator in a table cell

### DIFF
--- a/docs/conceptual/boolean-operators-[fsharp].md
+++ b/docs/conceptual/boolean-operators-[fsharp].md
@@ -24,7 +24,7 @@ The following table summarizes the Boolean operators that are available in the F
 |Operator|Description|
 |--------|-----------|
 |`not`|Boolean negation|
-|`||`|Boolean OR|
+|<code>&#124;&#124;</code>|Boolean OR|
 |`&&`|Boolean AND|
 
 The Boolean AND and OR operators perform *short-circuit evaluation*, that is, they evaluate the expression on the right of the operator only when it is necessary to determine the overall result of the expression. The second expression of the `&&` operator is evaluated only if the first expression evaluates to `true`; the second expression of the `||` operator is evaluated only if the first expression evaluates to `false`.


### PR DESCRIPTION
I'm not sure how to validate if this fix works or not, but here's my attempt at it anyhoo!

(Also, GitHub editor did something to the file ending, hope that doesn't break something)