### PR TITLE
Fix order of arguments in foldBack lambda

### DIFF
--- a/docs/conceptual/snippets/fslists/snippet41.fs
+++ b/docs/conceptual/snippets/fslists/snippet41.fs
@@ -1,4 +1,4 @@
-let sumListBack list = List.foldBack (fun acc elem -> acc + elem) list 0
+let sumListBack list = List.foldBack (fun elem acc -> acc + elem) list 0
 printfn "%d" (sumListBack [1; 2; 3])
 
 // For a calculation in which the order of traversal is important, fold and foldBack have different


### PR DESCRIPTION
Running the following in F# Interactive will help explain why I believe this change is necessary:
```fsharp
// How the arguments in the lambda function are currently ordered in the docs:
> List.foldBack (fun acc elem -> printf "elem: %A " elem; elem + acc) [1;2;3;4] 0;;
elem: 0 elem: 4 elem: 7 elem: 9 val it : int = 10

// The order I propose them to be in:
> List.foldBack (fun elem acc -> printf "elem: %A " elem; elem + acc) [1;2;3;4] 0;;
elem: 4 elem: 3 elem: 2 elem: 1 val it : int = 10
```

The accumulator is the second argument in foldBack (contrary to fold where it is the first).
Positioning the arguments in reverse in an example is a great way to confuse a reader.

This change also helps promote the fact that the state and list arguments to the folding function
are in the same order as their lambda counterparts.

Feel free to disagree :-).